### PR TITLE
README: 轉換到 Markdown 格式

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
-﻿# 說明書
-
-----------------------------------------------------------
-【小狼毫】輸入法 0.9
+【小狼毫】輸入法 說明書
+=======================
 
 基於 中州韻輸入法引擎／Rime Input Method Engine 等開源技術
 式恕堂 版權所無
@@ -13,8 +11,8 @@
   * 【中州韻】用於 Linux + IBus 輸入法框架
   * 【鼠鬚管】用於 Mac OS X 10.7+（64位）
 
-----------------------------------------------------------
 安裝輸入法
+----------
 
 本品適用於 Windows XP SP3,  32/64位 Windows 7
 
@@ -24,14 +22,16 @@
 
 安裝完成後，仍可由開始菜單打開「安裝選項」更改輸入語言。
 
-----------------------------------------------------------
 使用輸入法
+----------
+
 
 選取輸入法指示器菜單裏的【中】字樣圖標，開始用小狼毫寫字。
-可通過快捷鍵 Ctrl+` 或 F4 呼出方案選單、切換輸入方式。
+可通過快捷鍵 Ctrl+\` 或 F4 呼出方案選單、切換輸入方式。
 
-----------------------------------------------------------
 定製輸入法
+----------
+
 
 通過 開始菜單 » 小狼毫輸入法 訪問設定工具及常用位置。
 
@@ -42,40 +42,40 @@
 定製 Rime 的方法，請參考 Wiki 《定製指南》
 https://github.com/rime/home/wiki/CustomizationGuide
 
-----------------------------------------------------------
 致謝
+----
 
 輸入方案設計：
   * 【朙月拼音】系列及【八股文】詞典
-    數據來源於 CC-CEDICT、Android 拼音、新酷音、opencc 等開源項目
-    維護者 佛振 瑾昀
+    - 數據來源於 CC-CEDICT、Android 拼音、新酷音、opencc 等開源項目
+    - 維護者 佛振 瑾昀
   * 【注音／地球拼音】
-    維護者 佛振 瑾昀
+    - 維護者 佛振 瑾昀
   * 【倉頡五代】
-    發明人 朱邦復先生
-    碼表源自 www.chinesecj.com
-    構詞碼表作者 惜緣
-    輸入方案作者 佛振
+    - 發明人 朱邦復先生
+    - 碼表源自 www.chinesecj.com
+    - 構詞碼表作者 惜緣
+    - 輸入方案作者 佛振
   * 【五笔86】
-    發明人 王永民先生
-    碼表源自 ibus-table
+    - 發明人 王永民先生
+    - 碼表源自 ibus-table
   * 【粵拼】
-    採用《香港語言學學會粵語拼音方案》
-    http://www.lshk.org/
-    碼表源自 ibus-table
+    - 採用《香港語言學學會粵語拼音方案》
+    - http://www.lshk.org/
+    - 碼表源自 ibus-table
   * 【上海吳語】【蘇州吳語】
-    採用《吳語拉丁式注音法》
-    http://input.foruto.com/wu/method.html
-    作者 上海閒話abc、吳語越音、寒寒豆
+    - 採用《吳語拉丁式注音法》
+    - http://input.foruto.com/wu/method.html
+    - 作者 上海閒話abc、吳語越音、寒寒豆
   * 【中古全拼／三拼】
-    採用《廣韻》音系的中古漢語拼音，亦稱「古韻羅馬字」。
-    韻典網·廣韻 http://ytenx.org/kyonh/
-    http://zh.wikipedia.org/wiki/User:Polyhedron/中古漢語拼音
-    作者 Polyhedron
+    - 採用《廣韻》音系的中古漢語拼音，亦稱「古韻羅馬字」。
+    - 韻典網·廣韻 http://ytenx.org/kyonh/
+    - https://zh.wikipedia.org/wiki/User:Polyhedron/中古漢語拼音
+    - 作者 Polyhedron
   * 【X-SAMPA】
-    國際音標輸入法
-    http://zh.wikipedia.org/wiki/X-SAMPA
-    作者 Patrick Tschang、佛振
+    - 國際音標輸入法
+    - https://zh.wikipedia.org/wiki/X-SAMPA
+    - 作者 Patrick Tschang、佛振
 
 程序設計：
   * 佛振 <chen.sst@gmail.com>
@@ -98,17 +98,17 @@ https://github.com/rime/home/wiki/CustomizationGuide
   * WinSparkle  (MIT License)
   * yaml-cpp  (MIT License)
 
-----------------------------------------------------------
 問題與反饋
+----------
 
 發現程序有BUG，或建議，或感想，請到Rime項目網站反饋：
-http://code.google.com/p/rimeime/issues/list
+https://github.com/rime/weasel/issues
 
 已知問題
-  * 不支持 Windows 命令行和全屏遊戲
+  * 不支持 Windows 命令行和全屏遊戲 (#41)
 
-----------------------------------------------------------
 聯繫方式
+--------
 
 技術交流請寄 Rime 開發者 <rime-devel@googlegroups.com>
 或登錄 網上論壇：
@@ -118,5 +118,3 @@ http://groups.google.com/group/rime-devel
 http://tieba.baidu.com/f?kw=rime
 
 謝謝！
-
-----------------------------------------------------------


### PR DESCRIPTION
轉換掉的話 GitHub 網頁上會更好看一點。轉換時考慮了作爲 txt 的可讀性，所以問題也不大，倒是可能需要在安裝器裏面加一些重命名的邏輯好讓用戶想到去點開。

順便還更新了 issue 報告鏈接。

感覺這個 PR 也該 Cherry-Pick 到別的 branch 上。