### PR TITLE
refactor(ipc): extract pipe channel and server

### DIFF
--- a/WeaselIPC/PipeChannel.cpp
+++ b/WeaselIPC/PipeChannel.cpp
@@ -1,0 +1,146 @@
+#include "stdafx.h"
+
+#include <PipeChannel.h>
+
+using namespace weasel;
+using namespace std;
+using namespace boost;
+
+#define _ThrowLastError throw GetLastError()
+
+
+PipeChannelBase::PipeChannelBase(std::wstring &pn_cmd, size_t bs = 4 * 1024, SECURITY_ATTRIBUTES *s = NULL)
+	: cmd_name(pn_cmd),
+	msg_name(pn_cmd), // TBD: request msg pipe from cmd pipe
+	write_stream(nullptr),
+	buff_size(bs),
+	buffer(std::make_unique<char[]>(bs)),
+	msg_pipe(INVALID_HANDLE_VALUE),
+	cmd_pipe(INVALID_HANDLE_VALUE),
+	has_body(false),
+	sa(s) {};
+
+PipeChannelBase::PipeChannelBase(PipeChannelBase &&r)
+	: cmd_name(r.cmd_name),
+	write_stream(std::move(r.write_stream)),
+	buff_size(r.buff_size),
+	buffer(std::move(r.buffer)),
+	msg_pipe(r.msg_pipe),
+	cmd_pipe(r.cmd_pipe),
+	has_body(r.has_body),
+	sa(r.sa) {};
+
+
+PipeChannelBase::~PipeChannelBase()
+{
+	_FinalizePipe(msg_pipe);
+	_FinalizePipe(cmd_pipe);
+}
+
+bool PipeChannelBase::_Ensure()
+{
+	try {
+		/* TBD: Request message pipe from command pipe */
+		if (_Invalid(msg_pipe)) {
+			//msg_pipe = _Connect(msg_name.c_str());
+			msg_pipe = _Connect(cmd_name.c_str());
+			return !_Invalid(msg_pipe);
+		}
+	}
+	catch (...) {
+		return false;
+	}
+
+	return true;
+}
+
+HANDLE PipeChannelBase::_Connect(const wchar_t *name)
+{
+	HANDLE pipe = INVALID_HANDLE_VALUE;
+	while (_Invalid(pipe = _TryConnect(name)))
+		::WaitNamedPipe(name, 500);
+	DWORD mode = PIPE_READMODE_MESSAGE;
+	if (!SetNamedPipeHandleState(pipe, &mode, NULL, NULL)) {
+		_ThrowLastError;
+	}
+	return pipe;
+}
+
+void PipeChannelBase::_Reconnect(HANDLE pipe)
+{
+	_FinalizePipe(pipe);
+	_Ensure();
+}
+
+HANDLE PipeChannelBase::_TryConnect(const wchar_t *name)
+{
+	DWORD connectErr;
+	auto pipe = ::CreateFile(name, GENERIC_READ | GENERIC_WRITE, 0, NULL, OPEN_EXISTING, 0, NULL);
+
+	if (!_Invalid(pipe)) {
+		// connected to the pipe
+		return pipe;
+	}
+	// being busy is not really an error since we just need to wait.
+	if ((connectErr = ::GetLastError()) != ERROR_PIPE_BUSY) {
+
+		throw connectErr; // otherwise, pipe creation fails
+	}
+	// All pipe instances are busy
+	return INVALID_HANDLE_VALUE;
+}
+
+size_t PipeChannelBase::_WritePipe(HANDLE p, size_t s, char *b)
+{
+	DWORD lwritten;
+	if (!::WriteFile(p, b, s, &lwritten, NULL) || lwritten <= 0) {
+		_ThrowLastError;
+	}
+	::FlushFileBuffers(p);
+	return lwritten;
+}
+
+void PipeChannelBase::_FinalizePipe(HANDLE pipe)
+{
+	if (!_Invalid(pipe)) {
+		DisconnectNamedPipe(pipe);
+		CloseHandle(pipe);
+		pipe = INVALID_HANDLE_VALUE;
+	}
+
+}
+
+void PipeChannelBase::_Receive(HANDLE pipe, LPVOID msg, size_t rec_len)
+{
+	DWORD lread;
+	BOOL success = ::ReadFile(pipe, msg, rec_len, &lread, NULL);
+	if (!success) {
+		if (GetLastError() != ERROR_MORE_DATA) {
+			_ThrowLastError;
+		}
+		memset(buffer.get(), 0, buff_size);
+		success = ::ReadFile(pipe, buffer.get(), buff_size, &lread, NULL);
+		if (!success) {
+			_ThrowLastError;
+		}
+	}
+	has_body = false;
+}
+
+HANDLE PipeChannelBase::_ConnectServerPipe(std::wstring &pn)
+{
+	HANDLE pipe = CreateNamedPipe(
+		pn.c_str(),
+		PIPE_ACCESS_DUPLEX,
+		PIPE_TYPE_MESSAGE | PIPE_READMODE_MESSAGE | PIPE_WAIT,
+		PIPE_UNLIMITED_INSTANCES,
+		buff_size,
+		buff_size,
+		0,
+		sa);
+	if (pipe == INVALID_HANDLE_VALUE || !::ConnectNamedPipe(pipe, NULL)) {
+		_ThrowLastError;
+	}
+	return pipe;
+}
+

--- a/WeaselIPC/WeaselClientImpl.cpp
+++ b/WeaselIPC/WeaselClientImpl.cpp
@@ -58,6 +58,7 @@ void ClientImpl::Disconnect()
 {
 	if (_Active())
 		EndSession();
+	channel.Disconnect();
 }
 
 void ClientImpl::ShutdownServer()
@@ -192,7 +193,7 @@ LRESULT ClientImpl::_SendMessage(WEASEL_IPC_COMMAND Msg, DWORD wParam, DWORD lPa
 		PipeMessage req{ Msg, wParam, lParam };
 		return channel.Transact(req);
 	}
-	catch (...) {
+	catch (DWORD ex) {
 		return 0;
 	}
 }

--- a/WeaselIPC/WeaselClientImpl.cpp
+++ b/WeaselIPC/WeaselClientImpl.cpp
@@ -51,11 +51,6 @@ void ClientImpl::_InitializeClientInfo()
 
 bool ClientImpl::Connect(ServerLauncher const& launcher)
 {
-	//auto pipe_name = GetPipeName();
-
-	//_ConnectPipe(pipe_name.c_str());
-
-	//return _Connected();
 	return channel.Connect();
 }
 
@@ -136,9 +131,6 @@ void ClientImpl::FocusOut()
 
 void ClientImpl::StartSession()
 {
-	//if (!channel._Connected())
-	//	return;
-
 	if (_Active() && Echo())
 		return;
 

--- a/WeaselIPC/WeaselClientImpl.h
+++ b/WeaselIPC/WeaselClientImpl.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <WeaselIPC.h>
+#include <PipeChannel.h>
 
 namespace weasel
 {
@@ -27,27 +28,28 @@ namespace weasel
 		bool GetResponseData(ResponseHandler const& handler);
 
 	protected:
-		void _ConnectPipe(const wchar_t* pipeName);
 		void _InitializeClientInfo();
 		bool _WriteClientInfo();
 
 		LRESULT _SendMessage(WEASEL_IPC_COMMAND Msg, DWORD wParam, DWORD lParam);
 
-		bool _Connected() const { return pipe != INVALID_HANDLE_VALUE; }
-		bool _Active() const { return _Connected() && session_id != 0; }
+		bool _Connected() const { return channel.Connected(); }
+		bool _Active() const { return channel.Connected() && session_id != 0; }
 
-		inline WCHAR* _GetSendBuffer() const {
-			return reinterpret_cast<WCHAR*>((char *)buffer.get() + sizeof(PipeMessage));
-		}
+		//inline WCHAR* _GetSendBuffer() const {
+		//	return reinterpret_cast<WCHAR *>(channel.GetBuffer());
+		//}
 
 	private:
 		UINT session_id;
-		HANDLE pipe;
-		bool has_cnt;
+		//HANDLE pipe;
+		//bool has_cnt;
 
-		std::unique_ptr<char[]> buffer;
+		//std::unique_ptr<char[]> buffer;
 		std::wstring app_name;
 		bool is_ime;
+
+		PipeChannel<PipeMessage> channel;
 	};
 
 }

--- a/WeaselIPC/WeaselIPC.vcxproj
+++ b/WeaselIPC/WeaselIPC.vcxproj
@@ -265,6 +265,7 @@
   <ItemGroup>
     <ClCompile Include="Configurator.cpp" />
     <ClCompile Include="Deserializer.cpp" />
+    <ClCompile Include="PipeChannel.cpp" />
     <ClCompile Include="ResponseParser.cpp" />
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
@@ -282,6 +283,7 @@
     <ClCompile Include="ContextUpdater.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\include\PipeChannel.h" />
     <ClInclude Include="Configurator.h" />
     <ClInclude Include="Deserializer.h" />
     <ClInclude Include="..\include\ResponseParser.h" />

--- a/WeaselIPC/WeaselIPC.vcxproj.filters
+++ b/WeaselIPC/WeaselIPC.vcxproj.filters
@@ -45,6 +45,9 @@
     <ClCompile Include="Configurator.cpp">
       <Filter>Source Files\Deserializer</Filter>
     </ClCompile>
+    <ClCompile Include="PipeChannel.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Deserializer.h">
@@ -76,6 +79,9 @@
     </ClInclude>
     <ClInclude Include="Configurator.h">
       <Filter>Header Files\Deserializer</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\PipeChannel.h">
+      <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/WeaselIPCServer/SecurityAttribute.cpp
+++ b/WeaselIPCServer/SecurityAttribute.cpp
@@ -1,0 +1,78 @@
+#include "stdafx.h"
+#include "SecurityAttribute.h"
+
+#define SECURITY_APP_PACKAGE_AUTHORITY              {0,0,0,0,0,15}
+#define SECURITY_APP_PACKAGE_BASE_RID               (0x00000002L)
+#define SECURITY_BUILTIN_APP_PACKAGE_RID_COUNT      (2L)
+#define SECURITY_APP_PACKAGE_RID_COUNT              (8L)
+#define SECURITY_CAPABILITY_BASE_RID                (0x00000003L)
+#define SECURITY_BUILTIN_CAPABILITY_RID_COUNT       (2L)
+#define SECURITY_CAPABILITY_RID_COUNT               (5L)
+#define SECURITY_PARENT_PACKAGE_RID_COUNT           (SECURITY_APP_PACKAGE_RID_COUNT)
+#define SECURITY_CHILD_PACKAGE_RID_COUNT            (12L)
+#define SECURITY_BUILTIN_PACKAGE_ANY_PACKAGE        (0x00000001L)
+
+namespace weasel {
+
+	void SecurityAttribute::_Init()
+	{
+		memset(&ea, 0, sizeof(ea));
+
+		// 对一般 desktop APP 的权限设置
+
+		SID_IDENTIFIER_AUTHORITY worldSidAuthority = SECURITY_WORLD_SID_AUTHORITY;
+		AllocateAndInitializeSid(&worldSidAuthority, 1,
+			SECURITY_WORLD_RID, 0, 0, 0, 0, 0, 0, 0, &sid_everyone);
+
+		ea[0].grfAccessPermissions = GENERIC_ALL;
+		ea[0].grfAccessMode = SET_ACCESS;
+		ea[0].grfInheritance = SUB_CONTAINERS_AND_OBJECTS_INHERIT;
+		ea[0].Trustee.pMultipleTrustee = NULL;
+		ea[0].Trustee.MultipleTrusteeOperation = NO_MULTIPLE_TRUSTEE;
+		ea[0].Trustee.TrusteeForm = TRUSTEE_IS_SID;
+		ea[0].Trustee.TrusteeType = TRUSTEE_IS_WELL_KNOWN_GROUP;
+		ea[0].Trustee.ptstrName = (LPTSTR)sid_everyone;
+
+		// 对 winrt (UWP) APP 的权限设置
+		//
+		// Application Package Authority.
+		//
+
+
+		SID_IDENTIFIER_AUTHORITY appPackageAuthority = SECURITY_APP_PACKAGE_AUTHORITY;
+		AllocateAndInitializeSid(&appPackageAuthority,
+			SECURITY_BUILTIN_APP_PACKAGE_RID_COUNT,
+			SECURITY_APP_PACKAGE_BASE_RID,
+			SECURITY_BUILTIN_PACKAGE_ANY_PACKAGE,
+			0, 0, 0, 0, 0, 0, &sid_all_apps);
+
+		ea[1].grfAccessPermissions = GENERIC_ALL;
+		ea[1].grfAccessMode = SET_ACCESS;
+		ea[1].grfInheritance = SUB_CONTAINERS_AND_OBJECTS_INHERIT;
+		ea[1].Trustee.pMultipleTrustee = NULL;
+		ea[1].Trustee.MultipleTrusteeOperation = NO_MULTIPLE_TRUSTEE;
+		ea[1].Trustee.TrusteeForm = TRUSTEE_IS_SID;
+		ea[1].Trustee.TrusteeType = TRUSTEE_IS_GROUP;
+		ea[1].Trustee.ptstrName = (LPTSTR)sid_all_apps;
+
+		// create DACL
+		DWORD err = SetEntriesInAcl(2, ea, NULL, &pacl);
+		if (0 == err) {
+			// security descriptor
+			pd = (PSECURITY_DESCRIPTOR)LocalAlloc(LPTR, SECURITY_DESCRIPTOR_MIN_LENGTH);
+			InitializeSecurityDescriptor(pd, SECURITY_DESCRIPTOR_REVISION);
+
+			// Add the ACL to the security descriptor. 
+			SetSecurityDescriptorDacl(pd, TRUE, pacl, FALSE);
+		}
+
+		sa.nLength = sizeof(SECURITY_ATTRIBUTES);
+		sa.lpSecurityDescriptor = pd;
+		sa.bInheritHandle = TRUE;
+	}
+
+	SECURITY_ATTRIBUTES *SecurityAttribute::get_attr()
+	{
+		return &sa;
+	}
+};

--- a/WeaselIPCServer/SecurityAttribute.h
+++ b/WeaselIPCServer/SecurityAttribute.h
@@ -1,0 +1,19 @@
+#pragma once
+#include <winnt.h> // for security attributes constants
+#include <aclapi.h> // for ACL
+
+namespace weasel {
+	class SecurityAttribute {
+	private:
+		PSECURITY_DESCRIPTOR pd;
+		SECURITY_ATTRIBUTES sa;
+		PACL pacl;
+		EXPLICIT_ACCESS ea[2];
+		PSID sid_everyone;
+		PSID sid_all_apps;
+		void _Init();
+	public:
+		SecurityAttribute() { _Init(); }
+		SECURITY_ATTRIBUTES *get_attr();
+	};
+};

--- a/WeaselIPCServer/WeaselIPCServer.vcxproj
+++ b/WeaselIPCServer/WeaselIPCServer.vcxproj
@@ -263,6 +263,7 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="SecurityAttribute.cpp" />
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
@@ -276,6 +277,7 @@
     <ClCompile Include="WeaselServerImpl.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="SecurityAttribute.h" />
     <ClInclude Include="stdafx.h" />
     <ClInclude Include="targetver.h" />
     <ClInclude Include="..\include\WeaselIPC.h" />

--- a/WeaselIPCServer/WeaselIPCServer.vcxproj.filters
+++ b/WeaselIPCServer/WeaselIPCServer.vcxproj.filters
@@ -21,6 +21,9 @@
     <ClCompile Include="WeaselServerImpl.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="SecurityAttribute.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="stdafx.h">
@@ -33,6 +36,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="WeaselServerImpl.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="SecurityAttribute.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/WeaselIPCServer/WeaselServerImpl.cpp
+++ b/WeaselIPCServer/WeaselServerImpl.cpp
@@ -334,7 +334,7 @@ void PipeServer::Listen(ServerHandler const &handler)
 				_ProcessPipeThread(pipe, handler);
 			});
 		}
-		catch (...) {
+		catch (DWORD ex) {
 			_FinalizePipe(pipe);
 		}
 		boost::this_thread::interruption_point();

--- a/WeaselIPCServer/WeaselServerImpl.cpp
+++ b/WeaselIPCServer/WeaselServerImpl.cpp
@@ -329,7 +329,7 @@ void PipeServer::Listen(ServerHandler const &handler)
 		HANDLE pipe = INVALID_HANDLE_VALUE;
 		try {
 			boost::this_thread::interruption_point();
-			pipe = _ConnectServerPipe(msg_name);
+			pipe = _ConnectServerPipe(pname);
 			boost::thread th([&handler, pipe, this] {
 				_ProcessPipeThread(pipe, handler);
 			});

--- a/WeaselIPCServer/WeaselServerImpl.h
+++ b/WeaselIPCServer/WeaselServerImpl.h
@@ -10,25 +10,7 @@
 
 namespace weasel
 {
-
-	#define WEASEL_MSG_HANDLER(__name) DWORD __name (WEASEL_IPC_COMMAND, DWORD, LPARAM, BOOL&);
-
-	class PipeServer : public PipeChannel<DWORD, PipeMessage>
-	{
-	public:
-		using ServerRunner = std::function<void()>;
-		using Respond = std::function<void(Msg)>;
-		using ServerHandler = std::function<void(PipeMessage, Respond)>;
-
-		PipeServer(std::wstring &pn_cmd, SECURITY_ATTRIBUTES *s);
-
-	public:
-		void Listen(ServerHandler const &handler);
-		/* Get a server runner */
-		ServerRunner GetServerRunner(ServerHandler const &handler);
-	private:
-		void _ProcessPipeThread(HANDLE pipe, ServerHandler const &handler);
-	};
+	class PipeServer;
 
 	typedef CWinTraits<WS_DISABLED, WS_EX_TRANSPARENT> ServerWinTraits;
 
@@ -85,7 +67,8 @@ namespace weasel
 		}
 
 	private:
-		void HandlePipeMessage(PipeMessage pipe_msg, PipeServer::Respond resp);
+		template<typename _Resp>
+		void HandlePipeMessage(PipeMessage pipe_msg, _Resp resp);
 
 		std::unique_ptr<PipeServer> channel;
 		std::unique_ptr<boost::thread> pipeThread;

--- a/WeaselTSF/WeaselTSF.cpp
+++ b/WeaselTSF/WeaselTSF.cpp
@@ -216,6 +216,7 @@ void WeaselTSF::_EnsureServerConnected()
 {
 	if (!m_client.Echo())
 	{
+		m_client.Disconnect();
 		m_client.Connect(NULL);
 		m_client.StartSession();
 	}

--- a/include/PipeChannel.h
+++ b/include/PipeChannel.h
@@ -15,6 +15,10 @@ namespace weasel {
 		PipeChannelBase(PipeChannelBase &&r);
 		~PipeChannelBase();
 
+		bool Connect() { return _Ensure(); }
+		bool Connected() const { return !_Invalid(msg_pipe); }
+		void Disconnect() { _FinalizePipe(msg_pipe); }
+
 	protected:
 
 		/* To ensure connection before operation */
@@ -26,7 +30,7 @@ namespace weasel {
 		/* Try to connect for one time */
 		HANDLE _TryConnect(const wchar_t *name);
 		size_t _WritePipe(HANDLE p, size_t s, char *b);
-		void _FinalizePipe(HANDLE pipe);
+		void _FinalizePipe(HANDLE &pipe);
 		void _Receive(HANDLE pipe, LPVOID msg, size_t rec_len);
 		/* Try to get a connection from client */
 		HANDLE _ConnectServerPipe(std::wstring &pn);
@@ -127,8 +131,6 @@ namespace weasel {
 			return handler((LPWSTR)buffer.get(), buff_size * sizeof(char) / sizeof(wchar_t));
 		}
 
-		bool Connect() { return _Ensure(); }
-		bool Connected() const { return !_Invalid(msg_pipe); }
 
 	protected:
 

--- a/include/PipeChannel.h
+++ b/include/PipeChannel.h
@@ -1,0 +1,178 @@
+#pragma once
+#include <string>
+#include <memory>
+#include <windows.h>
+#include <boost/interprocess/streams/bufferstream.hpp>
+#include <boost/thread.hpp>
+
+namespace weasel {
+
+	class PipeChannelBase {
+	public:
+		using Stream = boost::interprocess::wbufferstream;
+
+		PipeChannelBase(std::wstring &pn_cmd, size_t bs, SECURITY_ATTRIBUTES *s);
+		PipeChannelBase(PipeChannelBase &&r);
+		~PipeChannelBase();
+
+	protected:
+
+		/* To ensure connection before operation */
+		bool _Ensure();
+		/* Connect pipe as client */
+		HANDLE _Connect(const wchar_t *name);
+		/* To reconnect message pipe */
+		void _Reconnect(HANDLE pipe);
+		/* Try to connect for one time */
+		HANDLE _TryConnect(const wchar_t *name);
+		size_t _WritePipe(HANDLE p, size_t s, char *b);
+		void _FinalizePipe(HANDLE pipe);
+		void _Receive(HANDLE pipe, LPVOID msg, size_t rec_len);
+		/* Try to get a connection from client */
+		HANDLE _ConnectServerPipe(std::wstring &pn);
+		inline bool _Invalid(HANDLE p) const { return p == INVALID_HANDLE_VALUE; }
+
+	protected:
+		std::wstring msg_name;
+		std::wstring cmd_name;
+		HANDLE msg_pipe;
+		HANDLE cmd_pipe;
+
+		bool has_body;
+		const size_t buff_size;
+		std::unique_ptr<char[]> buffer;
+		std::unique_ptr<Stream> write_stream;
+
+	private:
+		/* Security attributes */
+		SECURITY_ATTRIBUTES *sa;
+	};
+
+
+	/* Pipe based IPC channel */
+	template<
+		typename _TyMsg,
+		typename _TyRes = DWORD,
+		size_t _MsgSize = sizeof(_TyMsg),
+		size_t _ResSize = sizeof(_TyRes)>
+	class PipeChannel : public PipeChannelBase
+	{
+	public:
+
+		/* Type definitions */
+
+		using Ptr = std::shared_ptr<PipeChannel>;
+		using UPtr = std::unique_ptr<PipeChannel>;
+		using Msg = _TyMsg;
+		using Res = _TyRes;
+
+		enum class ChannalCommand {
+			NEW_MSG_PIPE,
+			REFRESH
+		};
+
+	public:
+		PipeChannel(std::wstring &pn_cmd, SECURITY_ATTRIBUTES *s = NULL, size_t bs = 4 * 1024)
+			: PipeChannelBase(pn_cmd, bs, s)
+		{}
+
+	public:
+		/* Common pipe operations */
+
+		/* Write data to buffer */
+		template<typename _TyWrite>
+		void Write(_TyWrite cnt)
+		{
+			has_body = true;
+			_BufferWriteStream() << cnt;
+		}
+
+		/* Write data to buffer */
+		template<typename _TyWrite>
+		PipeChannel& operator<<(_TyWrite cnt)
+		{
+			Write(cnt);
+			return *this;
+		}
+
+		_TyRes Transact(Msg &msg)
+		{
+			_Ensure();
+			_Send(msg_pipe, msg);
+			return _ReceiveResponse();
+		}
+
+
+		void ClearBufferStream()
+		{
+			has_body = false;
+			if (write_stream != nullptr) {
+				delete write_stream.release();
+				write_stream.reset(nullptr);
+			}
+		}
+
+		char *SendBuffer() const { return buffer.get() + _MsgSize; }
+
+		char *ReceiveBuffer() const { return buffer.get() + _ResSize; }
+
+		template<typename _TyHandler>
+		bool HandleResponseData(_TyHandler const &handler)
+		{
+			if (!handler) {
+				return false;
+			}
+
+			// Use whole buffer to receive data in client
+			return handler((LPWSTR)buffer.get(), buff_size * sizeof(char) / sizeof(wchar_t));
+		}
+
+		bool Connect() { return _Ensure(); }
+		bool Connected() const { return !_Invalid(msg_pipe); }
+
+	protected:
+
+		void _Send(HANDLE pipe, Msg &msg)
+		{
+			char *pbuff = buffer.get();
+			DWORD lwritten = 0;
+
+			*reinterpret_cast<Msg *>(pbuff) = msg;
+			size_t data_sz = has_body ? buff_size : _MsgSize;
+
+			_WritePipe(pipe, data_sz, pbuff);
+			ClearBufferStream();
+		}
+
+		_TyRes _ReceiveResponse()
+		{
+			_TyRes result;
+			_Receive(msg_pipe, &result, sizeof(result));
+			return result;
+		}
+
+		Stream& _BufferWriteStream()
+		{
+			if (write_stream == nullptr) {
+				char *pbuff = (char *)buffer.get() + _MsgSize;
+				memset(pbuff, 0, buff_size - _MsgSize);
+				write_stream = std::make_unique<Stream>((wchar_t *)pbuff, _SendBufferSizeW());
+			}
+			return *write_stream;
+		}
+
+	private:
+
+		inline size_t _SendBufferSizeW() const
+		{
+			return (buff_size - _MsgSize) * sizeof(char) / sizeof(wchar_t);
+		}
+
+		inline size_t _ReceiveBufferSizeW() const
+		{
+			return (buff_size - _ResSize) * sizeof(char) / sizeof(wchar_t);
+		}
+
+	};
+};
+

--- a/include/RimeWithWeasel.h
+++ b/include/RimeWithWeasel.h
@@ -18,7 +18,7 @@ public:
 	virtual UINT FindSession(UINT session_id);
 	virtual UINT AddSession(LPWSTR buffer);
 	virtual UINT RemoveSession(UINT session_id);
-	virtual BOOL ProcessKeyEvent(weasel::KeyEvent keyEvent, UINT session_id, LPWSTR buffer);
+	virtual BOOL ProcessKeyEvent(weasel::KeyEvent keyEvent, UINT session_id, EatLine eat);
 	virtual void CommitComposition(UINT session_id);
 	virtual void ClearComposition(UINT session_id);
 	virtual void FocusIn(DWORD param, UINT session_id);
@@ -33,7 +33,7 @@ private:
 	void _UpdateUI(UINT session_id);
 	void _LoadSchemaSpecificSettings(const std::string& schema_id);
 	bool _ShowMessage(weasel::Context& ctx, weasel::Status& status);
-	bool _Respond(UINT session_id, LPWSTR buffer);
+	bool _Respond(UINT session_id, EatLine eat);
 	void _ReadClientInfo(UINT session_id, LPWSTR buffer);
 
 	AppOptionsByAppName m_app_options;

--- a/include/WeaselIPC.h
+++ b/include/WeaselIPC.h
@@ -65,6 +65,7 @@ namespace weasel
 	// 處理請求之物件
 	struct RequestHandler
 	{
+		using EatLine = std::function<bool(std::wstring&)>;
 		RequestHandler() {}
 		virtual ~RequestHandler() {}
 		virtual void Initialize() {}
@@ -72,7 +73,7 @@ namespace weasel
 		virtual UINT FindSession(UINT session_id) { return 0; }
 		virtual UINT AddSession(LPWSTR buffer) { return 0; }
 		virtual UINT RemoveSession(UINT session_id) { return 0; }
-		virtual BOOL ProcessKeyEvent(KeyEvent keyEvent, UINT session_id, LPWSTR buffer) { return FALSE; }
+		virtual BOOL ProcessKeyEvent(KeyEvent keyEvent, UINT session_id, EatLine eat) { return FALSE; }
 		virtual void CommitComposition(UINT session_id) {}
 		virtual void ClearComposition(UINT session_id) {}
 		virtual void FocusIn(DWORD param, UINT session_id) {}

--- a/include/WeaselIPC.h
+++ b/include/WeaselIPC.h
@@ -31,8 +31,6 @@ enum WEASEL_IPC_COMMAND
 
 namespace weasel
 {
-	// 为了 32 位 server 和 64 位 TSF 的兼容，这里不用 LPARAM 和 WPARAM
-	// ServerImpl 处也有一样的问题。
 	struct PipeMessage {
 		WEASEL_IPC_COMMAND Msg;
 		UINT wParam;

--- a/test/TestWeaselIPC/TestWeaselIPC.cpp
+++ b/test/TestWeaselIPC/TestWeaselIPC.cpp
@@ -113,7 +113,7 @@ int console_main()
 
 int client_main()
 {
-	launch_server();
+	//launch_server();
 	Sleep(1000);
 	weasel::Client client;
 	if (!client.Connect())
@@ -168,12 +168,12 @@ public:
 		std::cerr << "RemoveClient: " << session_id << std::endl;
 		return 0;
 	}
-	virtual BOOL ProcessKeyEvent(weasel::KeyEvent keyEvent, UINT session_id, LPWSTR buffer) {
+	virtual BOOL ProcessKeyEvent(weasel::KeyEvent keyEvent, UINT session_id, EatLine eat) {
 		std::cerr << "ProcessKeyEvent: " << session_id 
 			  << " keycode: " << keyEvent.keycode 
 			  << " mask: " << keyEvent.mask 
 			  << std::endl;
-		wsprintf(buffer, L"Greeting=Hello, 小狼毫.\n");
+		eat(std::wstring(L"Greeting=Hello, 小狼毫.\n"));
 		return TRUE;
 	}
 private:

--- a/test/TestWeaselIPC/stdafx.h
+++ b/test/TestWeaselIPC/stdafx.h
@@ -15,5 +15,6 @@
 #include <atlbase.h>
 
 #include <wtl/atlapp.h>
+#include <string>
 
 extern CAppModule _Module;

--- a/weasel.sln
+++ b/weasel.sln
@@ -1,10 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.27130.2010
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{53F79A24-5390-4640-84B5-19984EB3353B}"
 	ProjectSection(SolutionItems) = preProject
+		include\PipeChannel.h = include\PipeChannel.h
 		include\PyWeasel.h = include\PyWeasel.h
 		include\ResponseParser.h = include\ResponseParser.h
 		include\RimeWithWeasel.h = include\RimeWithWeasel.h
@@ -171,5 +172,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {1756480B-0344-4FD7-9DD7-27D9BE5A14FF}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
- Extract pipe IPC from `ClientImpl` and `ServerImpl`
- Improve exception handling

Also as partial workaround for #110