### PR TITLE
feat(tsf): support user defined preedit display type

### DIFF
--- a/WeaselTSF/Composition.cpp
+++ b/WeaselTSF/Composition.cpp
@@ -280,7 +280,6 @@ void WeaselTSF::_UpdateComposition(ITfContext *pContext)
 
 	if (ok)
 	{
-		bool composing = _IsComposing();
 		if (!commit.empty())
 		{
 			// 修复顶字上屏的吞字问题：
@@ -289,13 +288,12 @@ void WeaselTSF::_UpdateComposition(ITfContext *pContext)
 			// 此时由于第五码的输入，composition 应是开启的，同时也要在输入处插入顶字。
 			// 这里先关闭上一个字的 composition，然后为后续输入开启一个新 composition。
 			// 有点 dirty 但是 it works ...
-			if (composing) {
+			if (_IsComposing()) {
 				_EndComposition(pContext);
-				composing = false;
 			}
 			_InsertText(pContext, commit);
 		}
-		if (status.composing && !composing)
+		if (status.composing && !_IsComposing())
 		{
 			if (!_fCUASWorkaroundTested)
 			{
@@ -309,12 +307,14 @@ void WeaselTSF::_UpdateComposition(ITfContext *pContext)
 			}
 			_StartComposition(pContext, _fCUASWorkaroundEnabled && !config.inline_preedit);
 		}
-		else if (!status.composing && composing) {
+		else if (!status.composing && _IsComposing())
+		{
 			_EndComposition(pContext);
-			composing = false;
 		}
-		if (composing && config.inline_preedit)
+		if (_IsComposing() && config.inline_preedit)
+		{
 			_ShowInlinePreedit(pContext, context);
+		}
 	}
 }
 

--- a/include/WeaselUI.h
+++ b/include/WeaselUI.h
@@ -18,11 +18,18 @@ namespace weasel
 		INLINE_PREEDIT_CAPABLE = 1,
 	};
 
+	enum PreeditType
+	{
+		COMPOSITION,
+		PREVIEW
+	};
+
 	struct UIStyle
 	{
 		std::wstring font_face;
 		int font_point;
 		bool inline_preedit;
+		PreeditType preedit_type;
 		bool display_tray_icon;
 		// layout
 		LayoutType layout_type;
@@ -55,6 +62,7 @@ namespace weasel
 		UIStyle() : font_face(), 
 			        font_point(0),
 					inline_preedit(false),
+					preedit_type(COMPOSITION),
 					display_tray_icon(false),
 					layout_type(LAYOUT_VERTICAL),
 					min_width(0),

--- a/output/data/weasel.yaml
+++ b/output/data/weasel.yaml
@@ -14,6 +14,7 @@ style:
   horizontal: false
   fullscreen: false
   inline_preedit: false
+  preedit_type: composition
   display_tray_icon: false
   layout:
     min_width: 160


### PR DESCRIPTION
- add config option `style/preedit_type(composition|preview)`

Set `style/preedit_type: preview` to display the first candidate as inline preedit.

![image](https://user-images.githubusercontent.com/10287709/36640259-11b1a79a-1a56-11e8-9fc2-f6b61c836e5f.png)
