### PR TITLE
fix(composition): fix crashes in notebook with inline preedit

### DIFF
--- a/WeaselTSF/Composition.cpp
+++ b/WeaselTSF/Composition.cpp
@@ -73,7 +73,7 @@ void WeaselTSF::_StartComposition(ITfContext *pContext, BOOL fCUASWorkaroundEnab
 	if ((pStartCompositionEditSession = new CStartCompositionEditSession(this, pContext, fCUASWorkaroundEnabled)) != NULL)
 	{
 		HRESULT hr;
-		pContext->RequestEditSession(_tfClientId, pStartCompositionEditSession, TF_ES_SYNC | TF_ES_READWRITE, &hr);
+		pContext->RequestEditSession(_tfClientId, pStartCompositionEditSession, TF_ES_ASYNCDONTCARE | TF_ES_READWRITE, &hr);
 		pStartCompositionEditSession->Release();
 	}
 }
@@ -114,7 +114,7 @@ void WeaselTSF::_EndComposition(ITfContext *pContext)
 
 	if ((pEditSession = new CEndCompositionEditSession(this, pContext, _pComposition)) != NULL)
 	{
-		pContext->RequestEditSession(_tfClientId, pEditSession, TF_ES_SYNC | TF_ES_READWRITE, &hr);
+		pContext->RequestEditSession(_tfClientId, pEditSession, TF_ES_ASYNCDONTCARE | TF_ES_READWRITE, &hr);
 		pEditSession->Release();
 	}
 }


### PR DESCRIPTION
This should fix the crashes referred in #109.

Since all synchronous edit sessions are processed before any pending asynchronous edit sessions, use sync for `CEndCompositionEditSession` and `CStartCompositionEditSession` may cause unexpected early session closing resulting in crash.

Theoretically this change may lost synchronization of `WeaselTSF::_IsComposing` according to the [document](https://msdn.microsoft.com/en-us/library/windows/desktop/ms538796(v=vs.85).aspx), but I found it is used by the Microsoft Sample IME...