### PR TITLE
chore(appveyor): move to Visual Studio 2017

### DIFF
--- a/appveyor.install.bat
+++ b/appveyor.install.bat
@@ -15,14 +15,14 @@ copy /Y librime\build\lib\Release\rime.dll output\
 
 if %nocache% == 1 (
 	pushd C:\Libraries
-	appveyor DownloadFile http://superb-sea2.dl.sourceforge.net/project/boost/boost/1.61.0/boost_1_61_0.7z
-	7z x boost_1_61_0.7z | find "ing archive"
-	cd boost_1_61_0
+	appveyor DownloadFile http://superb-sea2.dl.sourceforge.net/project/boost/boost/1.68.0/boost_1_68_0.7z
+	7z x boost_1_68_0.7z | find "ing archive"
+	cd boost_1_68_0
 	call .\bootstrap.bat
-	call .\b2.exe --prefix=%BOOST_ROOT% toolset=msvc-14.0 variant=release link=static threading=multi runtime-link=static define=BOOST_USE_WINAPI_VERSION=0x0501 cxxflags="/Zc:threadSafeInit- " --with-date_time --with-filesystem --with-locale --with-regex --with-signals --with-system --with-thread --with-serialization -q -d0 install
-	xcopy /e /i /y /q %BOOST_ROOT%\include\boost-1_61\boost %BOOST_ROOT%\boost
+	call .\b2.exe --prefix=%BOOST_ROOT% toolset=msvc-14.1 variant=release link=static threading=multi runtime-link=static define=BOOST_USE_WINAPI_VERSION=0x0501 cxxflags="/Zc:threadSafeInit- " --with-date_time --with-filesystem --with-locale --with-regex --with-signals --with-system --with-thread --with-serialization -q -d0 install
+	xcopy /e /i /y /q %BOOST_ROOT%\include\boost-1_68\boost %BOOST_ROOT%\boost
 	xcopy /e /i /y /q %BOOST_ROOT%\lib %BOOST_ROOT%\stage\lib
-	call .\b2.exe --prefix=%BOOST_ROOT%_x64 toolset=msvc-14.0 variant=release link=static threading=multi runtime-link=static address-model=64 define=BOOST_USE_WINAPI_VERSION=0x0501 cxxflags="/Zc:threadSafeInit- " --with-date_time --with-filesystem --with-locale --with-regex --with-signals --with-system --with-thread --with-serialization -q -d0 install
+	call .\b2.exe --prefix=%BOOST_ROOT%_x64 toolset=msvc-14.1 variant=release link=static threading=multi runtime-link=static address-model=64 define=BOOST_USE_WINAPI_VERSION=0x0502 cxxflags="/Zc:threadSafeInit- " --with-date_time --with-filesystem --with-locale --with-regex --with-signals --with-system --with-thread --with-serialization -q -d0 install
 	xcopy /e /i /y /q %BOOST_ROOT%_x64\lib %BOOST_ROOT%\stage_x64\lib
 	popd
 	if %ERRORLEVEL% NEQ 0 goto ERROR

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,10 +4,12 @@ pull_requests:
   do_not_increment_build_number: true
 
 version: '{branch} build {build}'
-image: Visual Studio 2015
+image: Visual Studio 2017
 
 environment:
   BOOST_ROOT: C:\Libraries\libboost
+  CMAKE_GENERATOR: "Visual Studio 15 2017"
+  PLATFORM_TOOLSET: v141_xp
 
 cache:
   - boost.cached -> appveyor.install.bat


### PR DESCRIPTION
It is time to move to the new platform.
This PR will be merged once AppVeyor CI check passes.