### PR TITLE
靜默安裝繁體版本指令

### DIFF
--- a/output/install.nsi
+++ b/output/install.nsi
@@ -170,7 +170,7 @@ program_files:
   ${GetOptions} $R0 "/S" $R1
   IfErrors +2 0
   StrCpy $R2 "/s"
-  ${GetOptions} $R0 "/T" $R1
+  ${GetOptions} $R0 "/S /T" $R1
   IfErrors +2 0
   StrCpy $R2 "/t"
 


### PR DESCRIPTION
將安裝繁體選項改爲 `/S /T`，以處理因`/S`被NSIS的Silent選項覆蓋而不能靜默安裝繁體小狼毫的情況。

（長遠可以考慮使用 `--setup=`，徹底繞過與NSIS預設的/S選項所相沖的問題。如：
```nsi
${GetOptions} $R0 "--setup=" $R1
StrCpy $R2 $R1
```