### PR TITLE
Fixed half-width charactor disappeared in Word

### DIFF
--- a/WeaselTSF/KeyEventSink.cpp
+++ b/WeaselTSF/KeyEventSink.cpp
@@ -45,6 +45,7 @@ STDAPI WeaselTSF::OnSetFocus(BOOL fForeground)
 
 STDAPI WeaselTSF::OnTestKeyDown(ITfContext *pContext, WPARAM wParam, LPARAM lParam, BOOL *pfEaten)
 {
+	_fTestKeyUpPending = FALSE;
 	if (_fTestKeyDownPending)
 	{
 		*pfEaten = TRUE;
@@ -59,6 +60,7 @@ STDAPI WeaselTSF::OnTestKeyDown(ITfContext *pContext, WPARAM wParam, LPARAM lPar
 
 STDAPI WeaselTSF::OnKeyDown(ITfContext *pContext, WPARAM wParam, LPARAM lParam, BOOL *pfEaten)
 {
+	_fTestKeyUpPending = FALSE;
 	if (_fTestKeyDownPending)
     {
 		_fTestKeyDownPending = FALSE;
@@ -74,6 +76,7 @@ STDAPI WeaselTSF::OnKeyDown(ITfContext *pContext, WPARAM wParam, LPARAM lParam, 
 
 STDAPI WeaselTSF::OnTestKeyUp(ITfContext *pContext, WPARAM wParam, LPARAM lParam, BOOL *pfEaten)
 {
+	_fTestKeyDownPending = FALSE;
 	if (_fTestKeyUpPending)
 	{
 		*pfEaten = TRUE;
@@ -88,6 +91,7 @@ STDAPI WeaselTSF::OnTestKeyUp(ITfContext *pContext, WPARAM wParam, LPARAM lParam
 
 STDAPI WeaselTSF::OnKeyUp(ITfContext *pContext, WPARAM wParam, LPARAM lParam, BOOL *pfEaten)
 {
+	_fTestKeyDownPending = FALSE;
 	if (_fTestKeyUpPending)
     {
 		_fTestKeyUpPending = FALSE;


### PR DESCRIPTION
Thank you for this great work!! We're happy we can contribute to weasel!

#### Fixed issues
https://github.com/rime/weasel/issues/221#issuecomment-388056345
https://github.com/rime/weasel/issues/273
https://github.com/rime/weasel/issues/317

#### Situation:
Type `123456789` in Word 2013, Win7

#### Expect:
`123456789`

#### Result in `ascii_mode`:
`123456789`

##### LOG
```
I0630 13:49:18.347062   308 engine.cc:99] process key: Shift+Shift_L
I0630 13:49:18.446949   308 engine.cc:99] process key: Shift+Release+Shift_L
I0630 13:49:18.446949   308 engine.cc:99] process key: Release+Shift_L
I0630 13:49:21.463521   308 engine.cc:99] process key: 1
I0630 13:49:21.883044   308 engine.cc:99] process key: Release+1
I0630 13:49:21.903021   308 engine.cc:99] process key: Release+1
I0630 13:49:21.903021   308 engine.cc:99] process key: 2
I0630 13:49:21.903021   308 engine.cc:99] process key: 2
I0630 13:49:21.962954   308 engine.cc:99] process key: Release+2
I0630 13:49:21.962954   308 engine.cc:99] process key: Release+2
I0630 13:49:22.262612   308 engine.cc:99] process key: 3
I0630 13:49:22.282590   308 engine.cc:99] process key: 3
I0630 13:49:22.322544   308 engine.cc:99] process key: Release+3
I0630 13:49:22.342522   308 engine.cc:99] process key: Release+3
I0630 13:49:22.662158   308 engine.cc:99] process key: 4
I0630 13:49:22.662158   308 engine.cc:99] process key: 4
I0630 13:49:22.762045   308 engine.cc:99] process key: Release+4
I0630 13:49:22.762045   308 engine.cc:99] process key: Release+4
I0630 13:49:23.061704   308 engine.cc:99] process key: 5
I0630 13:49:23.061704   308 engine.cc:99] process key: 5
I0630 13:49:23.181568   308 engine.cc:99] process key: Release+5
I0630 13:49:23.181568   308 engine.cc:99] process key: Release+5
...
```

#### Result not in `ascii_mode`:
`13579`
##### LOG
```
I0630 13:49:37.727262   308 engine.cc:99] process key: Shift+Shift_L
I0630 13:49:37.824352   308 engine.cc:99] process key: Shift+Release+Shift_L
I0630 13:49:37.840534   308 engine.cc:99] process key: Release+Shift_L
I0630 13:49:43.919778   308 engine.cc:99] process key: Return
I0630 13:49:44.000687   308 engine.cc:99] process key: Release+Return
I0630 13:49:44.016868   308 engine.cc:99] process key: Release+Return
I0630 13:49:45.926309   308 engine.cc:99] process key: 1
I0630 13:49:45.974854   308 engine.cc:99] process key: Release+1
I0630 13:49:45.974854   308 engine.cc:99] process key: Release+1
I0630 13:49:47.382663   308 engine.cc:99] process key: 2
I0630 13:49:47.495934   308 engine.cc:99] process key: Release+2
I0630 13:49:47.495934   308 engine.cc:99] process key: Release+2
I0630 13:49:48.059059   308 engine.cc:99] process key: Release+3
I0630 13:49:48.073623   308 engine.cc:99] process key: Release+3
I0630 13:49:48.408586   308 engine.cc:99] process key: 4
I0630 13:49:48.525094   308 engine.cc:99] process key: Release+4
I0630 13:49:48.525094   308 engine.cc:99] process key: Release+4
I0630 13:49:49.151329   308 engine.cc:99] process key: Release+5
I0630 13:49:49.165894   308 engine.cc:99] process key: Release+5
I0630 13:49:50.549435   308 engine.cc:99] process key: 6
...
```

#### Solutions
Clear `KeyDown pending status` when `KeyUp`
and clear `KeyUp pending status` when `KeyDown`, too