### PR TITLE
使用librime1.7.2，build.bat脚本更新

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -109,7 +109,10 @@ if %build_rime% == 1 (
   )
 
   cd %WEASEL_ROOT%\librime
-  if not exist librime\thirdparty\lib\opencc.lib (
+  if not exist env.bat (
+    copy %WEASEL_ROOT%\env.bat env.bat
+  )
+  if not exist thirdparty\lib\opencc.lib (
     call build.bat thirdparty %rime_build_variant%
     if errorlevel 1 goto error
   )

--- a/output/install.nsi
+++ b/output/install.nsi
@@ -156,7 +156,7 @@ program_files:
   ; opencc data files
   SetOutPath $INSTDIR\data\opencc
   File "data\opencc\*.json"
-  File "data\opencc\*.ocd"
+  File "data\opencc\*.ocd2"
   ; images
   SetOutPath $INSTDIR\data\preview
   File "data\preview\*.png"


### PR DESCRIPTION

使用librime 1.7.2 及build.bat变更：
`weasel\build.bat`在编译librime过程中`BOOST_ROOT`环境变量错误： librime1.7.2内`build.bat`会对[环境变量覆写] (https://github.com/rime/librime/blob/bcf811c37fed61ba9d5ee2317a36fccb78c3ddd4/build.bat#L8)  #608 
NSIS打包jnstaller会提示`*.ocd`文件不存在：新版本opencc输出文件后缀应为[`ocd2`](https://github.com/rime/weasel/issues/611#issuecomment-787005255)

测试环境[软件配置](https://github.com/crackself/weasel/blob/45f237f49b932874e745b9b56af0c6ce9c69342c/about_windows_compile.md)