### PR TITLE
 转义日文键盘中「变换」、「无变换」与「半角/全角」按键，使之在Windows中正常工作。

### DIFF
--- a/WeaselIME/KeyEvent.cpp
+++ b/WeaselIME/KeyEvent.cpp
@@ -99,8 +99,8 @@ ibus::Keycode TranslateKeycode(UINT vkey, KeyInfo kinfo)
 
 	case VK_ESCAPE:	return ibus::Escape;
 
-	//case VK_CONVERT:	return 0;
-	//case VK_NONCONVERT:	return 0;
+	case VK_CONVERT:	return ibus::Henkan;
+	case VK_NONCONVERT:	return ibus::Muhenkan;
 	//case VK_ACCEPT:	return 0;
 	//case VK_MODECHANGE:	return 0;
 
@@ -175,6 +175,9 @@ ibus::Keycode TranslateKeycode(UINT vkey, KeyInfo kinfo)
 	case VK_RCONTROL:	return ibus::Control_R;
 	case VK_LMENU:	return ibus::Alt_L;
 	case VK_RMENU:	return ibus::Alt_R;
+			
+	case VK_OEM_AUTO: return ibus::Zenkaku_Hankaku;
+	case VK_OEM_ENLW: return ibus::Zenkaku_Hankaku;
 	}
 	return ibus::Null;
 }

--- a/WeaselTSF/KeyEvent.cpp
+++ b/WeaselTSF/KeyEvent.cpp
@@ -99,8 +99,8 @@ ibus::Keycode TranslateKeycode(UINT vkey, KeyInfo kinfo)
 
 	case VK_ESCAPE:	return ibus::Escape;
 
-	//case VK_CONVERT:	return 0;
-	//case VK_NONCONVERT:	return 0;
+	case VK_CONVERT:	return ibus::Henkan;
+	case VK_NONCONVERT:	return ibus::Muhenkan;
 	//case VK_ACCEPT:	return 0;
 	//case VK_MODECHANGE:	return 0;
 
@@ -175,6 +175,10 @@ ibus::Keycode TranslateKeycode(UINT vkey, KeyInfo kinfo)
 	case VK_RCONTROL:	return ibus::Control_R;
 	case VK_LMENU:	return ibus::Alt_L;
 	case VK_RMENU:	return ibus::Alt_R;
+	
+	case VK_OEM_AUTO: return ibus::Zenkaku_Hankaku;
+	case VK_OEM_ENLW: return ibus::Zenkaku_Hankaku;
+	
 	}
 	return ibus::Null;
 }


### PR DESCRIPTION
在将ibus按键转义为Windows Virtual Keys时同时转义「变换」、「无变换」与「半角/全角」按键，使之在Windows中正常工作。