### PR TITLE
修复构建失败的问题

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -104,7 +104,7 @@ if %build_boost% == 1 (
 )
 
 if %build_rime% == 1 (
-  if not exist librime\build.bat (
+  if not exist deps\glog (
     git submodule update --init --recursive
   )
 
@@ -112,8 +112,8 @@ if %build_rime% == 1 (
   if not exist env.bat (
     copy %WEASEL_ROOT%\env.bat env.bat
   )
-  if not exist thirdparty\lib\opencc.lib (
-    call build.bat thirdparty %rime_build_variant%
+  if not exist lib\opencc.lib (
+    call build.bat deps %rime_build_variant%
     if errorlevel 1 goto error
   )
   call build.bat %rime_build_variant%
@@ -220,19 +220,19 @@ copy %WEASEL_ROOT%\plum\rime-install.bat output\
 set plum_dir=plum
 set rime_dir=output/data
 set WSLENV=plum_dir:rime_dir
-bash plum/rime-install %WEASEL_BUNDLED_RECIPES%
+call plum/rime-install.bat %WEASEL_BUNDLED_RECIPES%
 if errorlevel 1 goto error
 exit /b
 
 :build_opencc_data
-if not exist %WEASEL_ROOT%\librime\thirdparty\share\opencc\TSCharacters.ocd (
+if not exist %WEASEL_ROOT%\librime\share\opencc\TSCharacters.ocd (
   cd %WEASEL_ROOT%\librime
-  call build.bat thirdparty %rime_build_variant%
+  call build.bat deps %rime_build_variant%
   if errorlevel 1 goto error
 )
 cd %WEASEL_ROOT%
 if not exist output\data\opencc mkdir output\data\opencc
-copy %WEASEL_ROOT%\librime\thirdparty\share\opencc\*.* output\data\opencc\
+copy %WEASEL_ROOT%\librime\share\opencc\*.* output\data\opencc\
 if errorlevel 1 goto error
 exit /b
 

--- a/env.vs2017_xp.bat
+++ b/env.vs2017_xp.bat
@@ -3,7 +3,8 @@ rem Customize your build environment and save the modified copy to env.bat
 rem REQUIRED: path to Boost source directory
 set BOOST_ROOT=C:\Libraries\boost_1_69_0
 
-rem OPTIONAL: Visual Studio version and platform toolset
+rem OPTIONAL: architecture, Visual Studio version and platform toolset
+set ARCH=Win32
 set BJAM_TOOLSET=msvc-14.1
 set PLATFORM_TOOLSET=v141_xp
 

--- a/env.vs2019.bat
+++ b/env.vs2019.bat
@@ -6,7 +6,7 @@ rem REQUIRED: path to Boost source directory
 if not defined BOOST_ROOT set BOOST_ROOT=%WEASEL_ROOT%\deps\boost_1_78_0
 
 rem OPTIONAL: architecture, Visual Studio version and platform toolset
-rem set ARCH=Win32
+set ARCH=Win32
 set BJAM_TOOLSET=msvc-14.2
 set CMAKE_GENERATOR="Visual Studio 16 2019"
 set PLATFORM_TOOLSET=v142

--- a/env.vs2022.bat
+++ b/env.vs2022.bat
@@ -6,7 +6,7 @@ rem REQUIRED: path to Boost source directory
 if not defined BOOST_ROOT set BOOST_ROOT=%WEASEL_ROOT%\deps\boost_1_78_0
 
 rem OPTIONAL: architecture, Visual Studio version and platform toolset
-rem set ARCH=Win32
+set ARCH=Win32
 set BJAM_TOOLSET=msvc-14.3
 set CMAKE_GENERATOR="Visual Studio 17 2022"
 set PLATFORM_TOOLSET=v143

--- a/output/install.bat
+++ b/output/install.bat
@@ -37,7 +37,7 @@ rem regsvr32.exe /s "%CD%\weasel.dll"
 goto next
 
 :win7_x64_install
-WeaselSetupx64.exe %install_option%
+WeaselSetup.exe %install_option%
 rem regsvr32.exe /s "%CD%\weasel.dll"
 rem regsvr32.exe /s "%CD%\weaselx64.dll"
 goto next

--- a/output/uninstall.bat
+++ b/output/uninstall.bat
@@ -29,7 +29,7 @@ rem regsvr32.exe /s /u "%CD%\weasel.dll"
 goto next
 
 :win7_x64_uninstall
-WeaselSetupx64.exe /u
+WeaselSetup.exe /u
 rem regsvr32.exe /s /u "%CD%\weasel.dll"
 rem regsvr32.exe /s /u "%CD%\weaselx64.dll"
 goto next


### PR DESCRIPTION
1. CI使用的librime预构建，所以没出现构建失败的问题。https://github.com/rime/weasel/blob/e069d9703898af9286723b3e81ae3a3a54210bd8/github.install.bat#L10
2. 升级librime到1.8.5，现在依赖的版本中librime构建配置不支持指定32位，这会导致在64位系统上librime是64位，从而导致weasel构建失败 https://github.com/rime/librime/commit/305e801397075bd175bf5060f70905ab9c1412fb
3. 升级build.bat构建脚本以支持librime 1.8.5，同时修复output/install.bat和uninstall.bat脚本中，使用了不存在的weaselSetup64位程序，weaselSetup只有32位构建配置。https://github.com/rime/weasel/blob/e069d9703898af9286723b3e81ae3a3a54210bd8/output/install.bat#L39-L43 https://github.com/rime/weasel/blob/e069d9703898af9286723b3e81ae3a3a54210bd8/WeaselSetup/WeaselSetup.vcxproj#L36-L41