### PR TITLE
特性：支持方案自定义英文状态icon

### DIFF
--- a/RimeWithWeasel/RimeWithWeasel.cpp
+++ b/RimeWithWeasel/RimeWithWeasel.cpp
@@ -415,7 +415,8 @@ void RimeWithWeaselHandler::_LoadSchemaSpecificSettings(const std::string& schem
 		const int BUF_SIZE = 2047;
 		char buffer[BUF_SIZE + 1];
 		memset(buffer, '\0', sizeof(buffer));
-		if (RimeConfigGetString(&config, "schema/icon", buffer, BUF_SIZE))
+		if (RimeConfigGetString(&config, "schema/icon", buffer, BUF_SIZE)
+				|| RimeConfigGetString(&config, "schema/zhung_icon", buffer, BUF_SIZE))
 		{
 			std::wstring tmp = utf8towcs(buffer);
 			std::wstring user_dir = string_to_wstring(weasel_user_data_dir());
@@ -434,6 +435,27 @@ void RimeWithWeaselHandler::_LoadSchemaSpecificSettings(const std::string& schem
 		}
 		else
 			m_ui->style().current_zhung_icon = L"";
+
+		memset(buffer, '\0', sizeof(buffer));
+		if (RimeConfigGetString(&config, "schema/ascii_icon", buffer, BUF_SIZE))
+		{
+			std::wstring tmp = utf8towcs(buffer);
+			std::wstring user_dir = string_to_wstring(weasel_user_data_dir());
+			DWORD dwAttrib = GetFileAttributes((user_dir + L"\\" + tmp).c_str());
+			if (!(INVALID_FILE_ATTRIBUTES != dwAttrib && 0 == (dwAttrib & FILE_ATTRIBUTE_DIRECTORY)))
+			{
+				std::wstring share_dir = string_to_wstring(weasel_shared_data_dir());
+				dwAttrib = GetFileAttributes((share_dir + L"\\" + tmp).c_str());
+				if (!(INVALID_FILE_ATTRIBUTES != dwAttrib && 0 == (dwAttrib & FILE_ATTRIBUTE_DIRECTORY)))
+					m_ui->style().current_ascii_icon = L"";
+				else
+					m_ui->style().current_ascii_icon = (share_dir + L"\\" + tmp);
+			}
+			else
+				m_ui->style().current_ascii_icon = user_dir + L"\\" + tmp;
+		}
+		else
+			m_ui->style().current_ascii_icon = L"";
 	}
 	// load schema icon end
 	RimeConfigClose(&config);

--- a/RimeWithWeasel/RimeWithWeasel.cpp
+++ b/RimeWithWeasel/RimeWithWeasel.cpp
@@ -1089,10 +1089,12 @@ void RimeWithWeaselHandler::_GetStatus(weasel::Status & stat, UINT session_id)
 		if (schema_id != m_last_schema_id)
 		{
 			m_last_schema_id = schema_id;
-			RimeSetOption(session_id, "__synced", false); // Sync new schema options with front end
-			_LoadSchemaSpecificSettings(schema_id);
-			_UpdateInlinePreeditStatus(session_id);			// in case of inline_preedit set in schema
-			_RefreshTrayIcon(session_id, _UpdateUICallback);	// refresh icon after schema changed
+			if(schema_id != ".default") {						// don't load for schema select menu
+				RimeSetOption(session_id, "__synced", false); // Sync new schema options with front end
+				_LoadSchemaSpecificSettings(schema_id);
+				_UpdateInlinePreeditStatus(session_id);			// in case of inline_preedit set in schema
+				_RefreshTrayIcon(session_id, _UpdateUICallback);	// refresh icon after schema changed
+			}
 		}
 		stat.schema_name = utf8towcs(status.schema_name);
 		stat.ascii_mode = !!status.is_ascii_mode;

--- a/WeaselServer/WeaselTrayIcon.cpp
+++ b/WeaselServer/WeaselTrayIcon.cpp
@@ -8,7 +8,7 @@ static UINT mode_icon[] = { IDI_ZH, IDI_ZH, IDI_EN, IDI_RELOAD };
 static const WCHAR *mode_label[] = { NULL, /*L"中文"*/ NULL, /*L"西文"*/ NULL, L"維護中" };
 
 WeaselTrayIcon::WeaselTrayIcon(weasel::UI &ui)
-	: m_style(ui.style()), m_status(ui.status()), m_mode(INITIAL), m_schema_icon()
+	: m_style(ui.style()), m_status(ui.status()), m_mode(INITIAL), m_schema_zhung_icon(), m_schema_ascii_icon()
 {
 }
 
@@ -50,18 +50,30 @@ void WeaselTrayIcon::Refresh()
 	/* change icon, when 
 		1,mode changed
 		2,icon changed
-		3,both m_schema_icon and m_style.current_zhung_icon empty(for initialize)
+		3,both m_schema_zhung_icon and m_style.current_zhung_icon empty(for initialize)
+		4,both m_schema_ascii_icon and m_style.current_ascii_icon empty(for initialize)
 	*/
 	if (mode != m_mode 
-			|| m_schema_icon != m_style.current_zhung_icon 
-			|| (m_schema_icon.empty() && m_style.current_zhung_icon.empty()))
+		|| m_schema_zhung_icon != m_style.current_zhung_icon 
+		|| (m_schema_zhung_icon.empty() && m_style.current_zhung_icon.empty())
+		|| m_schema_ascii_icon != m_style.current_ascii_icon 
+		|| (m_schema_ascii_icon.empty() && m_style.current_ascii_icon.empty())
+	)
 	{
 		m_mode = mode;
-		m_schema_icon = m_style.current_zhung_icon;
-		if(mode != ZHUNG || m_style.current_zhung_icon.empty())
-			SetIcon(mode_icon[mode]);
+		m_schema_zhung_icon = m_style.current_zhung_icon;
+		m_schema_ascii_icon = m_style.current_ascii_icon;
+		if(mode == ASCII) {
+			if(m_schema_ascii_icon.empty()) SetIcon(mode_icon[mode]);
+			else							SetIcon(m_schema_ascii_icon.c_str());
+		}
+		else if(mode == ZHUNG) {
+			if(m_schema_zhung_icon.empty()) SetIcon(mode_icon[mode]);
+			else							SetIcon(m_schema_zhung_icon.c_str());
+		}
 		else
-			SetIcon(m_style.current_zhung_icon.c_str());
+			SetIcon(mode_icon[mode]);
+
 		ShowIcon();
 		if (mode_label[mode])
 		{

--- a/WeaselServer/WeaselTrayIcon.cpp
+++ b/WeaselServer/WeaselTrayIcon.cpp
@@ -64,12 +64,16 @@ void WeaselTrayIcon::Refresh()
 		m_schema_zhung_icon = m_style.current_zhung_icon;
 		m_schema_ascii_icon = m_style.current_ascii_icon;
 		if(mode == ASCII) {
-			if(m_schema_ascii_icon.empty()) SetIcon(mode_icon[mode]);
-			else							SetIcon(m_schema_ascii_icon.c_str());
+			if(m_schema_ascii_icon.empty())
+				SetIcon(mode_icon[mode]);
+			else
+				SetIcon(m_schema_ascii_icon.c_str());
 		}
 		else if(mode == ZHUNG) {
-			if(m_schema_zhung_icon.empty()) SetIcon(mode_icon[mode]);
-			else							SetIcon(m_schema_zhung_icon.c_str());
+			if(m_schema_zhung_icon.empty()) 
+				SetIcon(mode_icon[mode]);
+			else
+				SetIcon(m_schema_zhung_icon.c_str());
 		}
 		else
 			SetIcon(mode_icon[mode]);

--- a/WeaselServer/WeaselTrayIcon.h
+++ b/WeaselServer/WeaselTrayIcon.h
@@ -24,6 +24,7 @@ protected:
 	weasel::UIStyle &m_style;
 	weasel::Status &m_status;
 	WeaselTrayMode m_mode;
-	std::wstring m_schema_icon;
+	std::wstring m_schema_zhung_icon;
+	std::wstring m_schema_ascii_icon;
 };
 

--- a/WeaselTSF/LanguageBar.cpp
+++ b/WeaselTSF/LanguageBar.cpp
@@ -34,7 +34,7 @@ static void HMENU2ITfMenu(HMENU hMenu, ITfMenu *pTfMenu)
 }
 
 CLangBarItemButton::CLangBarItemButton(com_ptr<WeaselTSF> pTextService, REFGUID guid, weasel::UIStyle& style)
-	: _status(0), _style(style), _current_schema_icon()
+	: _status(0), _style(style), _current_schema_zhung_icon(), _current_schema_ascii_icon()
 {
 	DllAddRef();
 
@@ -154,23 +154,43 @@ STDAPI CLangBarItemButton::OnMenuSelect(UINT wID)
 
 STDAPI CLangBarItemButton::GetIcon(HICON *phIcon)
 {
-	if (ascii_mode || _style.current_zhung_icon.empty())
-		*phIcon = (HICON)LoadImageW(
-			g_hInst,
-			MAKEINTRESOURCEW(ascii_mode ? IDI_EN : IDI_ZH),
-			IMAGE_ICON,
-			GetSystemMetrics(SM_CXSMICON),
-			GetSystemMetrics(SM_CYSMICON),
-			LR_SHARED);
+	if (ascii_mode)
+	{
+		if(_style.current_ascii_icon.empty())
+			*phIcon = (HICON)LoadImageW(
+					g_hInst,
+					MAKEINTRESOURCEW(IDI_EN),
+					IMAGE_ICON,
+					GetSystemMetrics(SM_CXSMICON),
+					GetSystemMetrics(SM_CYSMICON),
+					LR_SHARED);
+		else
+			*phIcon = (HICON)LoadImageW(
+					NULL,
+					_style.current_ascii_icon.c_str(),
+					IMAGE_ICON,
+					GetSystemMetrics(SM_CXSMICON),
+					GetSystemMetrics(SM_CYSMICON),
+					LR_LOADFROMFILE);
+	}
 	else
-	{ 
-		*phIcon = (HICON)LoadImageW(
-			NULL,
-			_style.current_zhung_icon.c_str(),
-			IMAGE_ICON,
-			GetSystemMetrics(SM_CXSMICON),
-			GetSystemMetrics(SM_CYSMICON),
-			LR_LOADFROMFILE);
+	{
+		if( _style.current_zhung_icon.empty()) 
+			*phIcon = (HICON)LoadImageW(
+					g_hInst,
+					MAKEINTRESOURCEW(IDI_ZH),
+					IMAGE_ICON,
+					GetSystemMetrics(SM_CXSMICON),
+					GetSystemMetrics(SM_CYSMICON),
+					LR_SHARED);
+		else
+			*phIcon = (HICON)LoadImageW(
+					NULL,
+					_style.current_zhung_icon.c_str(),
+					IMAGE_ICON,
+					GetSystemMetrics(SM_CXSMICON),
+					GetSystemMetrics(SM_CYSMICON),
+					LR_LOADFROMFILE);
 	}
 	return (*phIcon == NULL)? E_FAIL: S_OK;
 }
@@ -213,8 +233,14 @@ void CLangBarItemButton::UpdateWeaselStatus(weasel::Status stat)
 			_pLangBarItemSink->OnUpdate(TF_LBI_STATUS | TF_LBI_ICON);
 		}
 	}
-	if (_current_schema_icon != _style.current_zhung_icon) {
-		_current_schema_icon = _style.current_zhung_icon;
+	if (_current_schema_zhung_icon != _style.current_zhung_icon) {
+		_current_schema_zhung_icon = _style.current_zhung_icon;
+		if (_pLangBarItemSink) {
+			_pLangBarItemSink->OnUpdate(TF_LBI_STATUS | TF_LBI_ICON);
+		}
+	}
+	if (_current_schema_ascii_icon != _style.current_ascii_icon) {
+		_current_schema_ascii_icon = _style.current_ascii_icon;
 		if (_pLangBarItemSink) {
 			_pLangBarItemSink->OnUpdate(TF_LBI_STATUS | TF_LBI_ICON);
 		}

--- a/WeaselTSF/LanguageBar.h
+++ b/WeaselTSF/LanguageBar.h
@@ -41,6 +41,7 @@ private:
 	DWORD _status;
 	bool ascii_mode;
 	weasel::UIStyle& _style;
-	std::wstring _current_schema_icon;
+	std::wstring _current_schema_zhung_icon;
+	std::wstring _current_schema_ascii_icon;
 };
 

--- a/WeaselUI/WeaselPanel.cpp
+++ b/WeaselUI/WeaselPanel.cpp
@@ -17,6 +17,14 @@
 
 #pragma comment(lib, "Shcore.lib")
 
+template <class t0, class t1, class t2>
+inline void LoadIconNecessary(t0& a, t1& b, t2& c, int d) {
+	if(a == b) return;
+	a = b;
+	if (b.empty())	c.LoadIconW(d, STATUS_ICON_SIZE, STATUS_ICON_SIZE, LR_DEFAULTCOLOR);
+	else			c = (HICON)LoadImage(NULL, b.c_str(), IMAGE_ICON, STATUS_ICON_SIZE, STATUS_ICON_SIZE, LR_LOADFROMFILE);
+}
+
 WeaselPanel::WeaselPanel(weasel::UI& ui)
 	: m_layout(NULL),
 	m_ctx(ui.ctx()),
@@ -791,13 +799,8 @@ void WeaselPanel::DoPaint(CDCHandle dc)
 		// status icon (I guess Metro IME stole my idea :)
 		if (m_layout->ShouldDisplayStatusIcon()) {
 			// decide if custom schema zhung icon to show
-			if(m_current_zhung_icon != m_style.current_zhung_icon) {
-				m_current_zhung_icon = m_style.current_zhung_icon;
-				if (m_style.current_zhung_icon.empty())
-					m_iconEnabled.LoadIconW(IDI_ZH, STATUS_ICON_SIZE, STATUS_ICON_SIZE, LR_DEFAULTCOLOR);
-				else
-					m_iconEnabled = (HICON)LoadImage(NULL, m_style.current_zhung_icon.c_str(), IMAGE_ICON, STATUS_ICON_SIZE, STATUS_ICON_SIZE, LR_LOADFROMFILE);
-			} 
+			LoadIconNecessary(m_current_zhung_icon, m_style.current_zhung_icon, m_iconEnabled, IDI_ZH);
+			LoadIconNecessary(m_current_ascii_icon, m_style.current_ascii_icon, m_iconAlpha, IDI_EN);
 			CRect iconRect(m_layout->GetStatusIconRect());
 			if (m_istorepos && !m_ctx.aux.str.empty())
 				iconRect.OffsetRect(0, m_offsety_aux);

--- a/WeaselUI/WeaselPanel.h
+++ b/WeaselUI/WeaselPanel.h
@@ -104,6 +104,7 @@ private:
 	CIcon m_iconFull;
 	CIcon m_iconHalf;
 	std::wstring m_current_zhung_icon;
+	std::wstring m_current_ascii_icon;
 	// for gdiplus drawings
 	Gdiplus::GdiplusStartupInput _m_gdiplusStartupInput;
 	ULONG_PTR _m_gdiplusToken;

--- a/include/WeaselCommon.h
+++ b/include/WeaselCommon.h
@@ -277,6 +277,7 @@ namespace weasel
 		bool inline_preedit;
 		bool display_tray_icon;
 		std::wstring current_zhung_icon;
+		std::wstring current_ascii_icon;
 
 		std::wstring label_text_format;
 		std::wstring mark_text;
@@ -335,6 +336,7 @@ namespace weasel
 			preedit_type(COMPOSITION),
 			display_tray_icon(false),
 			current_zhung_icon(),
+			current_ascii_icon(),
 
 			label_text_format(L"%s."),
 			mark_text(),
@@ -400,6 +402,7 @@ namespace weasel
 					|| mark_text != st.mark_text
 					|| display_tray_icon != st.display_tray_icon
 					|| current_zhung_icon != st.current_zhung_icon
+					|| current_ascii_icon != st.current_ascii_icon
 					|| label_text_format != st.label_text_format
 					|| min_width != st.min_width
 					|| max_width != st.max_width
@@ -461,6 +464,7 @@ namespace boost {
 			ar & s.preedit_type;
 			ar & s.display_tray_icon;
 			ar & s.current_zhung_icon;
+			ar & s.current_ascii_icon;
 			ar & s.label_text_format;
 			// layout
 			ar & s.layout_type;


### PR DESCRIPTION
和之前方案文件（或者custom文件）中可以通过```schema/icon```设定方案对应的中文icon类似，新增英文状态图标可自定义选项如下，注意的是目前这两个选项都只支持ico文件。

```yaml
schema/ascii_icon: ascii_icon_file.ico

```
示例效果（这里有带style/display_tray_icon: true ,实际建议这个关闭，直接使用语言栏）

![enicon](https://github.com/rime/weasel/assets/4023160/82ab854c-20e7-41af-8505-1bbd9f309011)
