### PR TITLE
Enhance position

### DIFF
--- a/RimeWithWeasel/RimeWithWeasel.cpp
+++ b/RimeWithWeasel/RimeWithWeasel.cpp
@@ -921,6 +921,11 @@ static void _UpdateUIStyle(RimeConfig* config, weasel::UI* ui, bool initialize)
 		style.margin_y = style.hilite_padding;
 	else if (style.hilite_padding > -style.margin_y && style.margin_y < 0)
 		style.margin_y = -(style.hilite_padding);
+	Bool enhanced_postion = False;
+	if (RimeConfigGetBool(config, "style/enhanced_position", &enhanced_postion) || initialize)
+	{
+		style.enhanced_position = !!enhanced_postion;
+	}
 	// color scheme
 	if (initialize && RimeConfigGetString(config, "style/color_scheme", buffer, BUF_SIZE))
 		_UpdateUIStyleColor(config, style);

--- a/WeaselTSF/Composition.cpp
+++ b/WeaselTSF/Composition.cpp
@@ -128,11 +128,12 @@ void WeaselTSF::_EndComposition(com_ptr<ITfContext> pContext, BOOL clear)
 class CGetTextExtentEditSession: public CEditSession
 {
 public:
-	CGetTextExtentEditSession(com_ptr<WeaselTSF> pTextService, com_ptr<ITfContext> pContext, com_ptr<ITfContextView> pContextView, com_ptr<ITfComposition> pComposition)
+	CGetTextExtentEditSession(com_ptr<WeaselTSF> pTextService, com_ptr<ITfContext> pContext, com_ptr<ITfContextView> pContextView, com_ptr<ITfComposition> pComposition, bool enhancedPosition)
 		: CEditSession(pTextService, pContext)
 	{
 		_pContextView = pContextView;
 		_pComposition = pComposition;
+		_enhancedPosition = enhancedPosition;
 	}
 
 	/* ITfEditSession */
@@ -141,6 +142,7 @@ public:
 private:
 	com_ptr<ITfContextView> _pContextView;
 	com_ptr<ITfComposition> _pComposition;
+	bool _enhancedPosition;
 };
 
 STDAPI CGetTextExtentEditSession::DoEditSession(TfEditCookie ec)
@@ -159,6 +161,7 @@ STDAPI CGetTextExtentEditSession::DoEditSession(TfEditCookie ec)
 	if ((_pContextView->GetTextExt(ec, selection.range, &rc, &fClipped)) == S_OK && (rc.left != 0 || rc.top != 0))
 	{
 		// get the foreground window pos and check if rc from GetTextExt is out of window
+		if (_enhancedPosition)
 		{
 			HWND hwnd;
 			RECT rcForegroundWindow;
@@ -190,7 +193,7 @@ BOOL WeaselTSF::_UpdateCompositionWindow(com_ptr<ITfContext> pContext)
 	if (pContext->GetActiveView(&pContextView) != S_OK)
 		return FALSE;
 	com_ptr<CGetTextExtentEditSession> pEditSession;
-	pEditSession.Attach(new CGetTextExtentEditSession(this, pContext, pContextView, _pComposition));
+	pEditSession.Attach(new CGetTextExtentEditSession(this, pContext, pContextView, _pComposition, _cand->style().enhanced_position));
 	if (pEditSession == NULL)
 	{
 		return FALSE;

--- a/WeaselTSF/Composition.cpp
+++ b/WeaselTSF/Composition.cpp
@@ -165,7 +165,8 @@ STDAPI CGetTextExtentEditSession::DoEditSession(TfEditCookie ec)
 			hwnd = GetForegroundWindow();
 			::GetWindowRect(hwnd, &rcForegroundWindow);
 
-			if(rc.left < rcForegroundWindow.left || rc.top < rcForegroundWindow.top)
+			if(rc.left < rcForegroundWindow.left || rc.left > rcForegroundWindow.right
+					|| rc.top < rcForegroundWindow.top || rc.top > rcForegroundWindow.bottom)
 			{
 				POINT pt;
 				bool hasCaret = ::GetCaretPos(&pt);

--- a/include/WeaselCommon.h
+++ b/include/WeaselCommon.h
@@ -278,6 +278,7 @@ namespace weasel
 		bool display_tray_icon;
 		std::wstring current_zhung_icon;
 		std::wstring current_ascii_icon;
+		bool enhanced_position;
 
 		std::wstring label_text_format;
 		std::wstring mark_text;
@@ -337,6 +338,7 @@ namespace weasel
 			display_tray_icon(false),
 			current_zhung_icon(),
 			current_ascii_icon(),
+			enhanced_position(false),
 
 			label_text_format(L"%s."),
 			mark_text(),
@@ -403,6 +405,7 @@ namespace weasel
 					|| display_tray_icon != st.display_tray_icon
 					|| current_zhung_icon != st.current_zhung_icon
 					|| current_ascii_icon != st.current_ascii_icon
+					|| enhanced_position != st.enhanced_position
 					|| label_text_format != st.label_text_format
 					|| min_width != st.min_width
 					|| max_width != st.max_width
@@ -465,6 +468,7 @@ namespace boost {
 			ar & s.display_tray_icon;
 			ar & s.current_zhung_icon;
 			ar & s.current_ascii_icon;
+			ar& s.enhanced_position;
 			ar & s.label_text_format;
 			// layout
 			ar & s.layout_type;


### PR DESCRIPTION
1. 光标跟随改善：改善部分获取光标位置失败导致光标位置在屏幕左上角的问题，异常时光标位移到窗口左上角位置。


光标位置问题改善例子，fontforge（应用原因，微软拼音也无法准确获取光标位置）
![TAMNP40N1%2QL@$X0IDHG X](https://github.com/rime/weasel/assets/4023160/02212fef-e29b-4a56-b12c-08fc393f9693)
