### PR TITLE
WIP: composition 光标修复

### DIFF
--- a/WeaselTSF/Composition.cpp
+++ b/WeaselTSF/Composition.cpp
@@ -239,8 +239,11 @@ STDAPI CInlinePreeditEditSession::DoEditSession(TfEditCookie ec)
 	_pTextService->_SetCompositionDisplayAttributes(ec, _pContext, pRangeComposition);
 
 	/* Set caret */
+	LONG cch;
 	TF_SELECTION tfSelection;
-	pRangeComposition->Collapse(ec, TF_ANCHOR_END);
+	pRangeComposition->Collapse(ec, TF_ANCHOR_START);
+	pRangeComposition->ShiftStart(ec, sel_end, &cch, NULL);
+	// pRangeComposition->ShiftEnd(ec, sel_end, &cch, NULL);
 	tfSelection.range = pRangeComposition;
 	tfSelection.style.ase = TF_AE_NONE;
 	tfSelection.style.fInterimChar = FALSE;


### PR DESCRIPTION
基本上是 #887 的问题，但 librime 的原因没法完全修复这个问题，讨论见 https://github.com/fxliang/weasel/commit/9deabef36d868ea3ccf227d37165953660821413 。

在 `RimeGetContext` 中，没法区分光标位于最初始侧的位置还是最后的位置，如：

`|abc` 在 `RimeGetContext` 中，返回的 curor 是 `0, 3` ，而 `abc|` 同样返回的是 `0, 3` ，所以 TSF 没法区分这两种状况，按 librime  的数据来就会在两种情况都将光标放到最后面。

GIF 图：

![c](https://github.com/rime/weasel/assets/16241583/c409e89d-2eb0-444d-8cc3-2c4554c72653)

@lotem 