### PR TITLE
修复inline_preedit模式下，preedit字体与下划线颜色问题

### DIFF
--- a/WeaselTSF/DisplayAttributeInfo.cpp
+++ b/WeaselTSF/DisplayAttributeInfo.cpp
@@ -8,7 +8,7 @@ const WCHAR _daiDescription[] = L"Weasel Display Attribute Input";
 
 const TF_DISPLAYATTRIBUTE _daiDisplayAttribute =
 {
-    { TF_CT_COLORREF, RGB(0, 0, 0) },   // text color
+    { TF_CT_COLORREF, RGB(255, 0, 0) },   // text color
     { TF_CT_NONE, 0 },                  // background color (TF_CT_NONE => app default)
     TF_LS_DOT,                          // underline style
     FALSE,                              // underline boldness

--- a/WeaselTSF/DisplayAttributeInfo.cpp
+++ b/WeaselTSF/DisplayAttributeInfo.cpp
@@ -6,13 +6,14 @@
 const WCHAR _daiInputName[] = L"DisplayAttributeInput";
 const WCHAR _daiDescription[] = L"Weasel Display Attribute Input";
 
+// change style only, leave color to app
 const TF_DISPLAYATTRIBUTE _daiDisplayAttribute =
 {
-    { TF_CT_COLORREF, RGB(255, 0, 0) },   // text color
+    { TF_CT_NONE, 0 },   		// text color
     { TF_CT_NONE, 0 },                  // background color (TF_CT_NONE => app default)
     TF_LS_DOT,                          // underline style
     FALSE,                              // underline boldness
-    { TF_CT_COLORREF, RGB(0, 0, 0) },   // underline color
+    { TF_CT_NONE, 0 },   		// underline color
     TF_ATTR_INPUT                       // attribute info
 };
 


### PR DESCRIPTION
#893 提到的问题
修改DisplayAttributes属性为不修改字体和下划线颜色，交由应用自行决定
 ![图片](https://user-images.githubusercontent.com/4402707/242518168-8e3f262f-d211-45a6-8f25-59382cfabdb7.png)