### PR TITLE
修復vertical_auto_reverse顯示異常,支持方案內設定配色

### DIFF
--- a/WeaselUI/WeaselPanel.cpp
+++ b/WeaselUI/WeaselPanel.cpp
@@ -25,6 +25,14 @@ inline void LoadIconNecessary(t0& a, t1& b, t2& c, int d) {
 	else			c = (HICON)LoadImage(NULL, b.c_str(), IMAGE_ICON, STATUS_ICON_SIZE, STATUS_ICON_SIZE, LR_LOADFROMFILE);
 }
 
+template <class t0>
+inline void Swap(t0& a, t0& b)
+{
+	auto tmp = a;
+	a = b;
+	b = tmp;
+}
+
 WeaselPanel::WeaselPanel(weasel::UI& ui)
 	: m_layout(NULL),
 	m_ctx(ui.ctx()),
@@ -565,6 +573,10 @@ bool WeaselPanel::_DrawPreeditBack(Text const& text, CDCHandle dc, CRect const& 
 
 				rc_hi.InflateRect(m_style.hilite_padding, m_style.hilite_padding);
 				IsToRoundStruct rd = m_layout->GetTextRoundInfo();
+				if(m_istorepos) {
+					Swap(rd.IsTopLeftNeedToRound, rd.IsBottomLeftNeedToRound);
+					Swap(rd.IsTopRightNeedToRound, rd.IsBottomRightNeedToRound);
+				}
 				_HighlightText(dc, rc_hi, m_style.hilited_back_color, m_style.hilited_shadow_color, m_style.round_corner, BackType::TEXT, rd);
 			}
 		}
@@ -594,9 +606,19 @@ bool WeaselPanel::_DrawCandidates(CDCHandle &dc, bool back)
 			for (auto i = 0; i < m_candidateCount && i < MAX_CANDIDATES_COUNT; ++i) {
 				if (i == m_ctx.cinfo.highlighted) continue;	// draw non hilited candidates only 
 				rect = m_layout->GetCandidateRect((int)i);
-				if(m_istorepos) rect.OffsetRect(0, m_offsetys[i]);
-				rect.InflateRect(m_style.hilite_padding, m_style.hilite_padding);
 				IsToRoundStruct rd = m_layout->GetRoundInfo(i);
+				if(m_istorepos) {
+					rect.OffsetRect(0, m_offsetys[i]);
+					if(i == 0) {
+						Swap(rd.IsTopLeftNeedToRound, rd.IsBottomLeftNeedToRound);
+						Swap(rd.IsTopRightNeedToRound, rd.IsBottomRightNeedToRound);
+					}
+					if(i == m_candidateCount - 1) {
+						Swap(rd.IsTopLeftNeedToRound, rd.IsBottomLeftNeedToRound);
+						Swap(rd.IsTopRightNeedToRound, rd.IsBottomRightNeedToRound);
+					}
+				}
+				rect.InflateRect(m_style.hilite_padding, m_style.hilite_padding);
 				_HighlightText(dc, rect, 0x00000000, m_style.candidate_shadow_color, m_style.round_corner, bkType, rd);
 				drawn = true;
 			}
@@ -608,9 +630,19 @@ bool WeaselPanel::_DrawCandidates(CDCHandle &dc, bool back)
 			for (auto i = 0; i < m_candidateCount && i < MAX_CANDIDATES_COUNT; ++i) {
 				if (i == m_ctx.cinfo.highlighted) continue;
 				rect = m_layout->GetCandidateRect((int)i);
-				if(m_istorepos) rect.OffsetRect(0, m_offsetys[i]);
-				rect.InflateRect(m_style.hilite_padding, m_style.hilite_padding);
 				IsToRoundStruct rd = m_layout->GetRoundInfo(i);
+				if(m_istorepos) {
+					rect.OffsetRect(0, m_offsetys[i]);
+					if(i == 0) {
+						Swap(rd.IsTopLeftNeedToRound, rd.IsBottomLeftNeedToRound);
+						Swap(rd.IsTopRightNeedToRound, rd.IsBottomRightNeedToRound);
+					}
+					if(i == m_candidateCount - 1) {
+						Swap(rd.IsTopLeftNeedToRound, rd.IsBottomLeftNeedToRound);
+						Swap(rd.IsTopRightNeedToRound, rd.IsBottomRightNeedToRound);
+					}
+				}
+				rect.InflateRect(m_style.hilite_padding, m_style.hilite_padding);
 				_HighlightText(dc, rect, m_style.candidate_back_color, 0x00000000, m_style.round_corner, bkType, rd, m_style.candidate_border_color);
 				drawn = true;
 			}
@@ -618,9 +650,19 @@ bool WeaselPanel::_DrawCandidates(CDCHandle &dc, bool back)
 		// draw highlighted back ground and shadow
 		{
 			rect = m_layout->GetHighlightRect();
-			if(m_istorepos) rect.OffsetRect(0, m_offsetys[m_ctx.cinfo.highlighted]);
-			rect.InflateRect(m_style.hilite_padding, m_style.hilite_padding);
 			IsToRoundStruct rd = m_layout->GetRoundInfo(m_ctx.cinfo.highlighted);
+			if(m_istorepos) {
+				rect.OffsetRect(0, m_offsetys[m_ctx.cinfo.highlighted]);
+				if(m_ctx.cinfo.highlighted == 0) {
+					Swap(rd.IsTopLeftNeedToRound, rd.IsBottomLeftNeedToRound);
+					Swap(rd.IsTopRightNeedToRound, rd.IsBottomRightNeedToRound);
+				}
+				if(m_ctx.cinfo.highlighted == m_candidateCount - 1) {
+					Swap(rd.IsTopLeftNeedToRound, rd.IsBottomLeftNeedToRound);
+					Swap(rd.IsTopRightNeedToRound, rd.IsBottomRightNeedToRound);
+				}
+			}
+			rect.InflateRect(m_style.hilite_padding, m_style.hilite_padding);
 			_HighlightText(dc, rect, m_style.hilited_candidate_back_color, m_style.hilited_candidate_shadow_color, m_style.round_corner, bkType, rd, m_style.hilited_candidate_border_color);
 			drawn = true;
 		}
@@ -701,6 +743,39 @@ void WeaselPanel::DoPaint(CDCHandle dc)
 	if(!hide_candidates){
 		CRect auxrc = m_layout->GetAuxiliaryRect();
 		CRect preeditrc = m_layout->GetPreeditRect();
+		if(m_istorepos)
+		{
+			CRect* rects = new CRect[m_candidateCount];
+			int* btmys = new int[m_candidateCount];
+			for (auto i = 0; i < m_candidateCount && i < MAX_CANDIDATES_COUNT; ++i) {
+				rects[i] = m_layout->GetCandidateRect(i);
+				btmys[i] = rects[i].bottom;
+			}
+			if (m_candidateCount) {
+				if (!m_layout->IsInlinePreedit() && !m_ctx.preedit.str.empty())
+					m_offsety_preedit = rects[m_candidateCount - 1].bottom - preeditrc.bottom;
+				if (!m_ctx.aux.str.empty())
+					m_offsety_aux = rects[m_candidateCount - 1].bottom - auxrc.bottom;
+			}
+			else {
+				m_offsety_preedit = 0;
+				m_offsety_aux = 0;
+			}
+			int base_gap = 0;
+			if (!m_ctx.aux.str.empty())
+				base_gap = auxrc.Height() + m_style.spacing;
+			else if (!m_layout->IsInlinePreedit() && !m_ctx.preedit.str.empty())
+				base_gap = preeditrc.Height() + m_style.spacing;
+
+			for (auto i = 0; i < m_candidateCount && i < MAX_CANDIDATES_COUNT; ++i) {
+				if (i == 0)
+					m_offsetys[i] = btmys[m_candidateCount - i - 1] - base_gap - rects[i].bottom;
+				else
+					m_offsetys[i] = (rects[i - 1].top + m_offsetys[i - 1] - m_style.candidate_spacing) - rects[i].bottom;
+			}
+			delete[] rects;
+			delete[] btmys;
+		}
 		// background and candidates back, hilite back drawing start
 		if (!m_ctx.empty()) {
 			CRect backrc = m_layout->GetContentRect();
@@ -801,14 +876,12 @@ void WeaselPanel::MoveTo(RECT const& rc)
 	if(CRect(rc) != m_oinputPos		// pos changed
 		|| m_octx != m_ctx
 		|| (m_style.inline_preedit && m_ctx.preedit.str.empty() && (CRect(rc) == m_oinputPos))	// after disabled by ctrl+space, inline_preedit
-		|| (!m_style.inline_preedit && CRect(rc) == m_oinputPos && m_ctx.preedit.str.length() == 2)	// for not inline_preedit, first input
 		|| !m_ctx.aux.str.empty()	// aux not empty, msg 
 		|| (m_ctx.aux.empty() && (m_layout) && m_layout->ShouldDisplayStatusIcon()))	// ascii icon
 	{
 		m_octx = m_ctx;
 		m_oinputPos = rc;
 		m_inputPos = rc;
-		if (m_style.shadow_offset_y >= 0)	m_inputPos.OffsetRect(0, 10);
 		// with parameter to avoid vertical flicker
 		_RepositionWindow(true);
 		RedrawWindow();
@@ -859,38 +932,8 @@ void WeaselPanel::_RepositionWindow(bool adj)
 		if (m_style.vertical_auto_reverse && m_style.layout_type == UIStyle::LAYOUT_VERTICAL)
 		{
 			m_istorepos = true;
-			CRect auxrc = m_layout->GetAuxiliaryRect();
-			CRect preeditrc = m_layout->GetPreeditRect();
-			CRect* rects = new CRect[m_candidateCount];
-			int* btmys = new int[m_candidateCount];
-			for (auto i = 0; i < m_candidateCount && i < MAX_CANDIDATES_COUNT; ++i) {
-				rects[i] = m_layout->GetCandidateRect(i);
-				btmys[i] = rects[i].bottom;
-			}
-			if (m_candidateCount) {
-				if (!m_layout->IsInlinePreedit() && !m_ctx.preedit.str.empty())
-					m_offsety_preedit = rects[m_candidateCount - 1].bottom - preeditrc.bottom;
-				if (!m_ctx.aux.str.empty())
-					m_offsety_aux = rects[m_candidateCount - 1].bottom - auxrc.bottom;
-			}
-			else {
-				m_offsety_preedit = 0;
-				m_offsety_aux = 0;
-			}
-			int base_gap = 0;
-			if (!m_ctx.aux.str.empty())
-				base_gap = auxrc.Height() + m_style.spacing;
-			else if (!m_layout->IsInlinePreedit() && !m_ctx.preedit.str.empty())
-				base_gap = preeditrc.Height() + m_style.spacing;
-
-			for (auto i = 0; i < m_candidateCount && i < MAX_CANDIDATES_COUNT; ++i) {
-				if (i == 0)
-					m_offsetys[i] = btmys[m_candidateCount - i - 1] - base_gap - rects[i].bottom;
-				else
-					m_offsetys[i] = (rects[i - 1].top + m_offsetys[i - 1] - m_style.candidate_spacing) - rects[i].bottom;
-			}
-			delete[] rects;
-			delete[] btmys;
+			if(adj) 
+				y += (m_style.shadow_offset_y >= 0) ? m_layout->offsetY : (COLORNOTTRANSPARENT(m_style.shadow_color)? 0 : (m_style.margin_y - m_style.hilite_padding));
 		}
 	}
 	if (y < rcWorkArea.top) y = rcWorkArea.top;		// over workarea top

--- a/WeaselUI/WeaselPanel.cpp
+++ b/WeaselUI/WeaselPanel.cpp
@@ -1,4 +1,5 @@
 ﻿#include "stdafx.h"
+#include <utility>
 #include "WeaselPanel.h"
 #include <WeaselCommon.h>
 #include <ShellScalingApi.h>
@@ -25,23 +26,15 @@ inline void LoadIconNecessary(t0& a, t1& b, t2& c, int d) {
 	else			c = (HICON)LoadImage(NULL, b.c_str(), IMAGE_ICON, STATUS_ICON_SIZE, STATUS_ICON_SIZE, LR_LOADFROMFILE);
 }
 
-template <class t0>
-inline void Swap(t0& a, t0& b)
-{
-	auto tmp = a;
-	a = b;
-	b = tmp;
-}
-
 static inline void ReconfigRoundInfo(IsToRoundStruct& rd, const int& i, const int& m_candidateCount)
 {
 	if(i == 0 && m_candidateCount > 1) {
-		Swap(rd.IsTopLeftNeedToRound, rd.IsBottomLeftNeedToRound);
-		Swap(rd.IsTopRightNeedToRound, rd.IsBottomRightNeedToRound);
+		std::swap(rd.IsTopLeftNeedToRound, rd.IsBottomLeftNeedToRound);
+		std::swap(rd.IsTopRightNeedToRound, rd.IsBottomRightNeedToRound);
 	}
 	if(i == m_candidateCount - 1) {
-		Swap(rd.IsTopLeftNeedToRound, rd.IsBottomLeftNeedToRound);
-		Swap(rd.IsTopRightNeedToRound, rd.IsBottomRightNeedToRound);
+		std::swap(rd.IsTopLeftNeedToRound, rd.IsBottomLeftNeedToRound);
+		std::swap(rd.IsTopRightNeedToRound, rd.IsBottomRightNeedToRound);
 	}
 }
 
@@ -586,8 +579,8 @@ bool WeaselPanel::_DrawPreeditBack(Text const& text, CDCHandle dc, CRect const& 
 				rc_hi.InflateRect(m_style.hilite_padding, m_style.hilite_padding);
 				IsToRoundStruct rd = m_layout->GetTextRoundInfo();
 				if(m_istorepos) {
-					Swap(rd.IsTopLeftNeedToRound, rd.IsBottomLeftNeedToRound);
-					Swap(rd.IsTopRightNeedToRound, rd.IsBottomRightNeedToRound);
+					std::swap(rd.IsTopLeftNeedToRound, rd.IsBottomLeftNeedToRound);
+					std::swap(rd.IsTopRightNeedToRound, rd.IsBottomRightNeedToRound);
 				}
 				_HighlightText(dc, rc_hi, m_style.hilited_back_color, m_style.hilited_shadow_color, m_style.round_corner, BackType::TEXT, rd);
 			}

--- a/WeaselUI/WeaselPanel.cpp
+++ b/WeaselUI/WeaselPanel.cpp
@@ -33,6 +33,18 @@ inline void Swap(t0& a, t0& b)
 	b = tmp;
 }
 
+static inline void ReconfigRoundInfo(IsToRoundStruct& rd, const int& i, const int& m_candidateCount)
+{
+	if(i == 0 && m_candidateCount > 1) {
+		Swap(rd.IsTopLeftNeedToRound, rd.IsBottomLeftNeedToRound);
+		Swap(rd.IsTopRightNeedToRound, rd.IsBottomRightNeedToRound);
+	}
+	if(i == m_candidateCount - 1) {
+		Swap(rd.IsTopLeftNeedToRound, rd.IsBottomLeftNeedToRound);
+		Swap(rd.IsTopRightNeedToRound, rd.IsBottomRightNeedToRound);
+	}
+}
+
 WeaselPanel::WeaselPanel(weasel::UI& ui)
 	: m_layout(NULL),
 	m_ctx(ui.ctx()),
@@ -609,14 +621,7 @@ bool WeaselPanel::_DrawCandidates(CDCHandle &dc, bool back)
 				IsToRoundStruct rd = m_layout->GetRoundInfo(i);
 				if(m_istorepos) {
 					rect.OffsetRect(0, m_offsetys[i]);
-					if(i == 0) {
-						Swap(rd.IsTopLeftNeedToRound, rd.IsBottomLeftNeedToRound);
-						Swap(rd.IsTopRightNeedToRound, rd.IsBottomRightNeedToRound);
-					}
-					if(i == m_candidateCount - 1) {
-						Swap(rd.IsTopLeftNeedToRound, rd.IsBottomLeftNeedToRound);
-						Swap(rd.IsTopRightNeedToRound, rd.IsBottomRightNeedToRound);
-					}
+					ReconfigRoundInfo(rd, i, m_candidateCount);
 				}
 				rect.InflateRect(m_style.hilite_padding, m_style.hilite_padding);
 				_HighlightText(dc, rect, 0x00000000, m_style.candidate_shadow_color, m_style.round_corner, bkType, rd);
@@ -633,14 +638,7 @@ bool WeaselPanel::_DrawCandidates(CDCHandle &dc, bool back)
 				IsToRoundStruct rd = m_layout->GetRoundInfo(i);
 				if(m_istorepos) {
 					rect.OffsetRect(0, m_offsetys[i]);
-					if(i == 0) {
-						Swap(rd.IsTopLeftNeedToRound, rd.IsBottomLeftNeedToRound);
-						Swap(rd.IsTopRightNeedToRound, rd.IsBottomRightNeedToRound);
-					}
-					if(i == m_candidateCount - 1) {
-						Swap(rd.IsTopLeftNeedToRound, rd.IsBottomLeftNeedToRound);
-						Swap(rd.IsTopRightNeedToRound, rd.IsBottomRightNeedToRound);
-					}
+					ReconfigRoundInfo(rd, i, m_candidateCount);
 				}
 				rect.InflateRect(m_style.hilite_padding, m_style.hilite_padding);
 				_HighlightText(dc, rect, m_style.candidate_back_color, 0x00000000, m_style.round_corner, bkType, rd, m_style.candidate_border_color);
@@ -653,14 +651,7 @@ bool WeaselPanel::_DrawCandidates(CDCHandle &dc, bool back)
 			IsToRoundStruct rd = m_layout->GetRoundInfo(m_ctx.cinfo.highlighted);
 			if(m_istorepos) {
 				rect.OffsetRect(0, m_offsetys[m_ctx.cinfo.highlighted]);
-				if(m_ctx.cinfo.highlighted == 0) {
-					Swap(rd.IsTopLeftNeedToRound, rd.IsBottomLeftNeedToRound);
-					Swap(rd.IsTopRightNeedToRound, rd.IsBottomRightNeedToRound);
-				}
-				if(m_ctx.cinfo.highlighted == m_candidateCount - 1) {
-					Swap(rd.IsTopLeftNeedToRound, rd.IsBottomLeftNeedToRound);
-					Swap(rd.IsTopRightNeedToRound, rd.IsBottomRightNeedToRound);
-				}
+				ReconfigRoundInfo(rd, m_ctx.cinfo.highlighted, m_candidateCount);
 			}
 			rect.InflateRect(m_style.hilite_padding, m_style.hilite_padding);
 			_HighlightText(dc, rect, m_style.hilited_candidate_back_color, m_style.hilited_candidate_shadow_color, m_style.round_corner, bkType, rd, m_style.hilited_candidate_border_color);

--- a/WeaselUI/WeaselPanel.cpp
+++ b/WeaselUI/WeaselPanel.cpp
@@ -28,6 +28,7 @@ inline void LoadIconNecessary(t0& a, t1& b, t2& c, int d) {
 WeaselPanel::WeaselPanel(weasel::UI& ui)
 	: m_layout(NULL),
 	m_ctx(ui.ctx()),
+	m_octx(ui.octx()),
 	m_status(ui.status()),
 	m_style(ui.style()),
 	m_ostyle(ui.ostyle()),
@@ -798,11 +799,13 @@ void WeaselPanel::MoveTo(RECT const& rc)
 {
 	if(!m_layout)	return;			// avoid handling nullptr in _RepositionWindow 
 	if(CRect(rc) != m_oinputPos		// pos changed
+		|| m_octx != m_ctx
 		|| (m_style.inline_preedit && m_ctx.preedit.str.empty() && (CRect(rc) == m_oinputPos))	// after disabled by ctrl+space, inline_preedit
 		|| (!m_style.inline_preedit && CRect(rc) == m_oinputPos && m_ctx.preedit.str.length() == 2)	// for not inline_preedit, first input
 		|| !m_ctx.aux.str.empty()	// aux not empty, msg 
 		|| (m_ctx.aux.empty() && (m_layout) && m_layout->ShouldDisplayStatusIcon()))	// ascii icon
 	{
+		m_octx = m_ctx;
 		m_oinputPos = rc;
 		m_inputPos = rc;
 		if (m_style.shadow_offset_y >= 0)	m_inputPos.OffsetRect(0, 10);

--- a/WeaselUI/WeaselPanel.cpp
+++ b/WeaselUI/WeaselPanel.cpp
@@ -923,8 +923,10 @@ void WeaselPanel::_RepositionWindow(bool adj)
 		if (m_style.vertical_auto_reverse && m_style.layout_type == UIStyle::LAYOUT_VERTICAL)
 		{
 			m_istorepos = true;
-			if(adj) 
+			if(m_style.shadow_radius > 0 && adj) {
 				y += (m_style.shadow_offset_y >= 0) ? m_layout->offsetY : (COLORNOTTRANSPARENT(m_style.shadow_color)? 0 : (m_style.margin_y - m_style.hilite_padding));
+				y += m_style.shadow_radius / 2;
+			}
 		}
 	}
 	if (y < rcWorkArea.top) y = rcWorkArea.top;		// over workarea top

--- a/WeaselUI/WeaselPanel.h
+++ b/WeaselUI/WeaselPanel.h
@@ -84,6 +84,7 @@ private:
 
 	weasel::Layout *m_layout;
 	weasel::Context &m_ctx;
+	weasel::Context &m_octx;
 	weasel::Status &m_status;
 	weasel::UIStyle &m_style;
 	weasel::UIStyle &m_ostyle;

--- a/include/WeaselUI.h
+++ b/include/WeaselUI.h
@@ -52,6 +52,7 @@ namespace weasel
 		void Update(Context const& ctx, Status const& status);
 
 		Context& ctx() { return ctx_; } 
+		Context& octx() { return octx_; } 
 		Status& status() { return status_; } 
 		UIStyle& style() { return style_; }
 		UIStyle& ostyle() { return ostyle_; }
@@ -60,6 +61,7 @@ namespace weasel
 		UIImpl* pimpl_;
 
 		Context ctx_;
+		Context octx_;
 		Status status_;
 		UIStyle style_;
 		UIStyle ostyle_;


### PR DESCRIPTION
1. 修復vertical_auto_reverse狀態下部分狀態不能正常顯示候選的問題
2. 修復vertical_auto_reverse狀態，天圓地方的圓角狀態不正確的問題
3. 增加特性： 支持方案內設定（weasel.yaml中定義的）配色