### PR TITLE
fixed: font parsing bug when code point value with non-digit characte

### DIFF
--- a/WeaselServer/WeaselTrayIcon.cpp
+++ b/WeaselServer/WeaselTrayIcon.cpp
@@ -60,6 +60,7 @@ void WeaselTrayIcon::Refresh()
 		|| (m_schema_ascii_icon.empty() && m_style.current_ascii_icon.empty())
 	)
 	{
+		ShowIcon();
 		m_mode = mode;
 		m_schema_zhung_icon = m_style.current_zhung_icon;
 		m_schema_ascii_icon = m_style.current_ascii_icon;
@@ -78,7 +79,6 @@ void WeaselTrayIcon::Refresh()
 		else
 			SetIcon(mode_icon[mode]);
 
-		ShowIcon();
 		if (mode_label[mode])
 		{
 			ShowBalloon(mode_label[mode], WEASEL_IME_NAME);

--- a/WeaselUI/fontClasses.cpp
+++ b/WeaselUI/fontClasses.cpp
@@ -2,6 +2,8 @@
 #include <string>
 #include "fontClasses.h"
 
+#define STYLEORWEIGHT	(L":[^:]*[^a-f0-9:]+[^:]*")	
+
 std::vector<std::wstring> ws_split(const std::wstring& in, const std::wstring& delim) 
 {
 	std::wregex re{ delim };
@@ -112,7 +114,7 @@ HRESULT DirectWriteResources::InitResources(std::wstring label_font_face, int la
 	DWRITE_FONT_STYLE fontStyle = DWRITE_FONT_STYLE_NORMAL;
 	// setup font weight and font style by the first unit of font_face setting string
 	_ParseFontFace(fontFaceStrVector[0], fontWeight, fontStyle);
-	fontFaceStrVector[0] = std::regex_replace(fontFaceStrVector[0], std::wregex(L":[a-zA-Z_]+", std::wregex::icase), L"");
+	fontFaceStrVector[0] = std::regex_replace(fontFaceStrVector[0], std::wregex(STYLEORWEIGHT, std::wregex::icase), L"");
 	hResult = pDWFactory->CreateTextFormat(_mainFontFace.c_str(), NULL,
 			fontWeight, fontStyle, DWRITE_FONT_STRETCH_NORMAL,
 			font_point * dpiScaleX_, L"", reinterpret_cast<IDWriteTextFormat**>(&pTextFormat));
@@ -135,7 +137,7 @@ HRESULT DirectWriteResources::InitResources(std::wstring label_font_face, int la
 
 	fontFaceStrVector = ws_split(font_face, L",");
 	//_ParseFontFace(fontFaceStrVector[0], fontWeight, fontStyle);
-	fontFaceStrVector[0] = std::regex_replace(fontFaceStrVector[0], std::wregex(L":[a-zA-Z_]+", std::wregex::icase), L"");
+	fontFaceStrVector[0] = std::regex_replace(fontFaceStrVector[0], std::wregex(STYLEORWEIGHT, std::wregex::icase), L"");
 	hResult = pDWFactory->CreateTextFormat(_mainFontFace.c_str(), NULL,
 			fontWeight, fontStyle, DWRITE_FONT_STRETCH_NORMAL,
 			font_point * dpiScaleX_, L"", reinterpret_cast<IDWriteTextFormat**>(&pPreeditTextFormat));
@@ -159,7 +161,7 @@ HRESULT DirectWriteResources::InitResources(std::wstring label_font_face, int la
 	fontFaceStrVector = ws_split(label_font_face, L",");
 	// setup weight and style of label_font_face
 	_ParseFontFace(fontFaceStrVector[0], fontWeight, fontStyle);
-	fontFaceStrVector[0] = std::regex_replace(fontFaceStrVector[0], std::wregex(L":[a-zA-Z_]+", std::wregex::icase), L"");
+	fontFaceStrVector[0] = std::regex_replace(fontFaceStrVector[0], std::wregex(STYLEORWEIGHT, std::wregex::icase), L"");
 	hResult = pDWFactory->CreateTextFormat(_mainFontFace.c_str(), NULL,
 			fontWeight, fontStyle, DWRITE_FONT_STRETCH_NORMAL,
 			label_font_point * dpiScaleX_, L"", reinterpret_cast<IDWriteTextFormat**>(&pLabelTextFormat));
@@ -183,7 +185,7 @@ HRESULT DirectWriteResources::InitResources(std::wstring label_font_face, int la
 	fontFaceStrVector = ws_split(comment_font_face, L",");
 	// setup weight and style of label_font_face
 	_ParseFontFace(fontFaceStrVector[0], fontWeight, fontStyle);
-	fontFaceStrVector[0] = std::regex_replace(fontFaceStrVector[0], std::wregex(L":[a-zA-Z_]+", std::wregex::icase), L"");
+	fontFaceStrVector[0] = std::regex_replace(fontFaceStrVector[0], std::wregex(STYLEORWEIGHT, std::wregex::icase), L"");
 	hResult = pDWFactory->CreateTextFormat(_mainFontFace.c_str(), NULL,
 			fontWeight, fontStyle, DWRITE_FONT_STRETCH_NORMAL,
 			comment_font_point * dpiScaleX_, L"", reinterpret_cast<IDWriteTextFormat**>(&pCommentTextFormat));


### PR DESCRIPTION
1. 修复字体设定的start_code_point/end_code_point 只使用a-f组成时，对应的range解析不正确的问题。

2. 修复语言栏菜单通过鼠标点击部署时无显示装载中的图标的问题