### PR TITLE
fixed: style/layout/min_width not work for horizontal layout.

### DIFF
--- a/RimeWithWeasel/RimeWithWeasel.cpp
+++ b/RimeWithWeasel/RimeWithWeasel.cpp
@@ -812,6 +812,20 @@ static void _UpdateUIStyle(RimeConfig* config, weasel::UI* ui, bool initialize)
 		else if (!std::strcmp(preedit_type, "preview_all"))
 			style.preedit_type = weasel::UIStyle::PREVIEW_ALL;
 	}
+	char antialias_mode[20] = { 0 };
+	if (RimeConfigGetString(config, "style/antialias_mode", antialias_mode, sizeof(antialias_mode) - 1))
+	{
+		if (!std::strcmp(antialias_mode, "force_dword"))
+			style.antialias_mode = weasel::UIStyle::FORCE_DWORD;
+		else if (!std::strcmp(antialias_mode, "cleartype"))
+			style.antialias_mode = weasel::UIStyle::CLEARTYPE;
+		else if (!std::strcmp(antialias_mode, "grayscale"))
+			style.antialias_mode = weasel::UIStyle::GRAYSCALE;
+		else if (!std::strcmp(antialias_mode, "aliased"))
+			style.antialias_mode = weasel::UIStyle::ALIASED;
+		else
+			style.antialias_mode = weasel::UIStyle::DEFAULT;
+	}
 
 	char align_type[20] = { 0 };
 	if (RimeConfigGetString(config, "style/layout/align_type", align_type, sizeof(align_type) - 1))

--- a/WeaselUI/HorizontalLayout.cpp
+++ b/WeaselUI/HorizontalLayout.cpp
@@ -147,13 +147,9 @@ void HorizontalLayout::DoLayout(CDCHandle dc, DirectWriteResources* pDWR )
 			_candidateLabelRects[i].OffsetRect(0, ol);
 			_candidateTextRects[i].OffsetRect(0, ot);
 			_candidateCommentRects[i].OffsetRect(0, oc);
-			// make rightest candidate's rect right the same for better look
-			if(( i < candidates_count - 1 && row_of_candidate[i] < row_of_candidate[i+1] ) || (i == candidates_count - 1))
-				_candidateRects[i].right = max(width, max_width_of_rows);
 		}
 		height = mintop_of_rows[row_cnt] + height_of_rows[row_cnt] - offsetY;
 		width = max(width, max_width_of_rows);
-		_highlightRect = _candidateRects[id];
 	}
 	else
 		height -= _style.spacing + offsetY;
@@ -161,11 +157,21 @@ void HorizontalLayout::DoLayout(CDCHandle dc, DirectWriteResources* pDWR )
 	width += real_margin_x;
 	height += real_margin_y;
 
-	if (!_context.preedit.str.empty() && !candidates_count)
+	if (!_context.preedit.str.empty() && candidates_count)
 	{
 		width = max(width, _style.min_width);
 		height = max(height, _style.min_height);
 	}
+	if(candidates_count)
+	{
+		for (auto i = 0; i < candidates_count && i < MAX_CANDIDATES_COUNT; ++i)
+		{
+			// make rightest candidate's rect right the same for better look
+			if(( i < candidates_count - 1 && row_of_candidate[i] < row_of_candidate[i+1] ) || (i == candidates_count - 1))
+				_candidateRects[i].right = width - real_margin_x;
+		}
+	}
+	_highlightRect = _candidateRects[id];
 	UpdateStatusIconLayout(&width, &height);
 	_contentSize.SetSize(width + offsetX, height + 2 * offsetY);
 	_contentRect.SetRect(0, 0, _contentSize.cx, _contentSize.cy);

--- a/WeaselUI/WeaselPanel.cpp
+++ b/WeaselUI/WeaselPanel.cpp
@@ -153,7 +153,11 @@ void WeaselPanel::_InitFontRes(void)
 		pDWR = new DirectWriteResources(m_style, dpiX);
 	// if style changed, re-initialize font resources
 	else if (m_ostyle != m_style)
+	{
 		pDWR->InitResources(m_style, dpiX);
+		pDWR->pRenderTarget->SetTextAntialiasMode((D2D1_TEXT_ANTIALIAS_MODE)m_style.antialias_mode);
+
+	}
 	else if( dpiX != dpi)
 	{
 		pDWR->InitResources(m_style, dpiX);

--- a/WeaselUI/fontClasses.cpp
+++ b/WeaselUI/fontClasses.cpp
@@ -44,7 +44,7 @@ DirectWriteResources::DirectWriteResources(weasel::UIStyle& style, UINT dpi = 0)
 	pCommentTextFormat(NULL),
 	pTextLayout(NULL)
 {
-	// prepare d2d1 resources
+	D2D1_TEXT_ANTIALIAS_MODE mode = _style.antialias_mode <= 3 ? (D2D1_TEXT_ANTIALIAS_MODE)(_style.antialias_mode) : D2D1_TEXT_ANTIALIAS_MODE_FORCE_DWORD; // prepare d2d1 resources
 	HRESULT hResult = S_OK;
 	// create factory
 	if (pD2d1Factory == NULL)
@@ -58,7 +58,7 @@ DirectWriteResources::DirectWriteResources(weasel::UIStyle& style, UINT dpi = 0)
 		const D2D1_PIXEL_FORMAT format = D2D1::PixelFormat(DXGI_FORMAT_B8G8R8A8_UNORM, D2D1_ALPHA_MODE_PREMULTIPLIED);
 		const D2D1_RENDER_TARGET_PROPERTIES properties = D2D1::RenderTargetProperties(D2D1_RENDER_TARGET_TYPE_DEFAULT, format);
 		pD2d1Factory->CreateDCRenderTarget(&properties, &pRenderTarget);
-		pRenderTarget->SetTextAntialiasMode(D2D1_TEXT_ANTIALIAS_MODE_GRAYSCALE);
+		pRenderTarget->SetTextAntialiasMode(mode);
 		pRenderTarget->SetAntialiasMode(D2D1_ANTIALIAS_MODE_PER_PRIMITIVE);
 	}
 	//get the dpi information

--- a/include/WeaselCommon.h
+++ b/include/WeaselCommon.h
@@ -240,6 +240,15 @@ namespace weasel
 
 	struct UIStyle
 	{
+		enum AntiAliasMode
+		{
+			DEFAULT = 0,
+			CLEARTYPE = 1,
+			GRAYSCALE = 2,
+			ALIASED = 3,
+			FORCE_DWORD = 0xffffffff
+		};
+
 		enum PreeditType
 		{
 			COMPOSITION,
@@ -264,6 +273,7 @@ namespace weasel
 			ALIGN_TOP
 		};
 
+		AntiAliasMode antialias_mode;
 		LayoutAlignType align_type;
 		PreeditType preedit_type;
 		LayoutType layout_type;
@@ -334,6 +344,7 @@ namespace weasel
 			label_font_point(0),
 			comment_font_point(0),
 			inline_preedit(false),
+			antialias_mode(DEFAULT),
 			align_type(ALIGN_BOTTOM),
 			preedit_type(COMPOSITION),
 			display_tray_icon(false),
@@ -391,6 +402,7 @@ namespace weasel
 			return
 				(
 					align_type != st.align_type
+					|| antialias_mode != st.antialias_mode
 					|| preedit_type != st.preedit_type
 					|| layout_type != st.layout_type
 					|| vertical_text_left_to_right != st.vertical_text_left_to_right
@@ -464,6 +476,7 @@ namespace boost {
 			ar & s.comment_font_point;
 			ar & s.inline_preedit;
 			ar & s.align_type;
+			ar & s.antialias_mode;
 			ar & s.mark_text;
 			ar & s.preedit_type;
 			ar & s.display_tray_icon;

--- a/output/data/weasel.yaml
+++ b/output/data/weasel.yaml
@@ -10,6 +10,7 @@ app_options:
     ascii_mode: true
 
 style:
+  antialias_mode: default
   color_scheme: aqua
   font_face: Microsoft YaHei
   label_font_face: Microsoft YaHei


### PR DESCRIPTION
fix bug issue #908 
style/layout/min_width not work for horizontal layout.

feature: antialias mode optional
`style/antialias_mode: "default" | "cleartype" | "grayscale" | "aliased" | "force_dword" `