### PR TITLE
病毒误报改进 [skip ci]

### DIFF
--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build:
-    runs-on: windows-2019
+    runs-on: windows-2022
     env:
       boost_version: 1.78.0
       BOOST_ROOT: ${{ github.workspace }}\deps\boost_1_78_0
@@ -27,7 +27,7 @@ jobs:
 
       - name: Configure build environment
         run: |
-          copy env.vs2019.bat env.bat
+          copy env.vs2022.bat env.bat
           $git_ref_name = git describe --always
           echo "git_ref_name=$git_ref_name" >> $env:GITHUB_ENV
 

--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -9,7 +9,7 @@ jobs:
   build-and-release:
     permissions:
       contents: write
-    runs-on: windows-2019
+    runs-on: windows-2022
     env:
       boost_version: 1.78.0
       BOOST_ROOT: ${{ github.workspace }}\deps\boost_1_78_0
@@ -22,7 +22,7 @@ jobs:
 
       - name: Configure build environment
         run: |
-          copy env.vs2019.bat env.bat
+          copy env.vs2022.bat env.bat
           $git_ref_name = git describe --always
           echo "git_ref_name=$git_ref_name" >> $env:GITHUB_ENV
 

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ Thumbs.db
 release-notes.html
 *.7z
 RELEASE_CHANGELOG.md
+deps/

--- a/build.bat
+++ b/build.bat
@@ -153,18 +153,18 @@ del msbuild*.log
 
 if %build_hant% == 1 (
   if %build_x64% == 1 (
-    msbuild.exe weasel.sln %build_option% /p:Configuration=ReleaseHant /p:Platform="x64" /fl4
+    msbuild.exe weasel.sln %build_option% /p:Configuration=ReleaseHant /p:Platform="x64" /fl4 /m
     if errorlevel 1 goto error
   )
-  msbuild.exe weasel.sln %build_option% /p:Configuration=ReleaseHant /p:Platform="Win32" /fl3
+  msbuild.exe weasel.sln %build_option% /p:Configuration=ReleaseHant /p:Platform="Win32" /fl3 /m
   if errorlevel 1 goto error
 )
 
 if %build_x64% == 1 (
-  msbuild.exe weasel.sln %build_option% /p:Configuration=%build_config% /p:Platform="x64" /fl2
+  msbuild.exe weasel.sln %build_option% /p:Configuration=%build_config% /p:Platform="x64" /fl2 /m
   if errorlevel 1 goto error
 )
-msbuild.exe weasel.sln %build_option% /p:Configuration=%build_config% /p:Platform="Win32" /fl1
+msbuild.exe weasel.sln %build_option% /p:Configuration=%build_config% /p:Platform="Win32" /fl1 /m
 if errorlevel 1 goto error
 
 if %build_installer% == 1 (
@@ -179,28 +179,19 @@ goto end
 
 :build_boost
 
-set BOOST_COMPILED_LIBS=--with-date_time^
- --with-filesystem^
- --with-locale^
- --with-regex^
- --with-system^
- --with-thread^
- --with-serialization
-
-set BJAM_OPTIONS_COMMON=toolset=%BJAM_TOOLSET%^
- variant=%boost_build_variant%^
+set BJAM_OPTIONS_COMMON=-j%NUMBER_OF_PROCESSORS%^
+ --without-mpi^
+ define=BOOST_USE_WINAPI_VERSION=0x0603^
+ toolset=%BJAM_TOOLSET%^
  link=static^
- threading=multi^
  runtime-link=static^
- cxxflags="/Zc:threadSafeInit- "
+ --build-type=complete
 
 set BJAM_OPTIONS_X86=%BJAM_OPTIONS_COMMON%^
- define=BOOST_USE_WINAPI_VERSION=0x0501^
  architecture=x86^
  address-model=32
 
 set BJAM_OPTIONS_X64=%BJAM_OPTIONS_COMMON%^
- define=BOOST_USE_WINAPI_VERSION=0x0502^
  architecture=x86^
  address-model=64
 

--- a/build.bat
+++ b/build.bat
@@ -153,18 +153,18 @@ del msbuild*.log
 
 if %build_hant% == 1 (
   if %build_x64% == 1 (
-    msbuild.exe weasel.sln %build_option% /p:Configuration=ReleaseHant /p:Platform="x64" /fl4 /m
+    msbuild.exe weasel.sln %build_option% /p:Configuration=ReleaseHant /p:Platform="x64" /fl4
     if errorlevel 1 goto error
   )
-  msbuild.exe weasel.sln %build_option% /p:Configuration=ReleaseHant /p:Platform="Win32" /fl3 /m
+  msbuild.exe weasel.sln %build_option% /p:Configuration=ReleaseHant /p:Platform="Win32" /fl3
   if errorlevel 1 goto error
 )
 
 if %build_x64% == 1 (
-  msbuild.exe weasel.sln %build_option% /p:Configuration=%build_config% /p:Platform="x64" /fl2 /m
+  msbuild.exe weasel.sln %build_option% /p:Configuration=%build_config% /p:Platform="x64" /fl2
   if errorlevel 1 goto error
 )
-msbuild.exe weasel.sln %build_option% /p:Configuration=%build_config% /p:Platform="Win32" /fl1 /m
+msbuild.exe weasel.sln %build_option% /p:Configuration=%build_config% /p:Platform="Win32" /fl1
 if errorlevel 1 goto error
 
 if %build_installer% == 1 (


### PR DESCRIPTION
- 更改编译平台为 windows-2022
- 更改了 boost 的编译参数，并提升了目标操作系统版本至 Win 8.1
- 开启 boost 的并行编译
- **WeaselSetup 反而报毒变多，需要修改一下**（工具链换到 2022 后报毒就变多了）

对比：
| File | Proposed PR | https://github.com/rime/weasel/commit/e2679946367c8d780af64454591e8f889276af44 |
|--|--|--|
|WeaselServer.exe|3/70|13/68|
|WeaselDeployer.exe|3/69|1/71|
|WeaselSetup.exe|14/71|3/68|
|weasel.dll|0/70|0/70|

virustotal 链接：
https://www.virustotal.com/gui/file/4463d051c99121c0b38896e7b82b74b3372ccb471f85c0a87132811c2f3aa451?nocache=1
https://www.virustotal.com/gui/file/4313060c91dcbc26ed2b0505a82e766ab91260d69210b3d577f5ff9ece0dfe62?nocache=1
https://www.virustotal.com/gui/file/b8bd3f55fce06db3a7d5012697cd831cccb992ee6a85a5976728ac865572a91b?nocache=1
https://www.virustotal.com/gui/file/bc48ef17233e9b240444a3132ecb3b327c45a1c464711adb447537b6e34dde51?nocache=1

其他：
- 合并这个 PR 后，需要手动删除 GitHub Actions 的 boost cache
- 这个 PR 需要压缩并合并

CC: @fxliang @lotem 