### PR TITLE
界面若干bug修复

### DIFF
--- a/WeaselUI/HorizontalLayout.cpp
+++ b/WeaselUI/HorizontalLayout.cpp
@@ -24,8 +24,9 @@ void HorizontalLayout::DoLayout(CDCHandle dc, DirectWriteResources* pDWR )
 	CSize pgszl, pgszr;
 	GetTextSizeDW(pre, pre.length(), pDWR->pPreeditTextFormat, pDWR, &pgszl);
 	GetTextSizeDW(next, next.length(), pDWR->pPreeditTextFormat, pDWR, &pgszr);
-	int pgw = pgszl.cx + pgszr.cx + _style.hilite_spacing + _style.hilite_padding * 2;
-	int pgh = max(pgszl.cy, pgszr.cy);
+	bool page_en = (_style.prevpage_color & 0xff000000) && (_style.nextpage_color & 0xff000000);
+	int pgw = page_en ? (pgszl.cx + pgszr.cx + _style.hilite_spacing + _style.hilite_padding * 2) : 0;
+	int pgh = page_en ? max(pgszl.cy, pgszr.cy) : 0;
 
 	/* Preedit */
 	if (!IsInlinePreedit() && !_context.preedit.str.empty())
@@ -177,7 +178,7 @@ void HorizontalLayout::DoLayout(CDCHandle dc, DirectWriteResources* pDWR )
 	_contentRect.SetRect(0, 0, _contentSize.cx, _contentSize.cy);
 
 	// calc page indicator 
-	if(candidates_count && !_style.inline_preedit)
+	if(page_en && candidates_count && !_style.inline_preedit)
 	{
 		int _prex = _contentSize.cx - offsetX - real_margin_x + _style.hilite_padding - pgw;
 		int _prey = (_preeditRect.top + _preeditRect.bottom) / 2 - pgszl.cy / 2;

--- a/WeaselUI/StandardLayout.cpp
+++ b/WeaselUI/StandardLayout.cpp
@@ -83,42 +83,46 @@ CSize StandardLayout::GetPreeditSize(CDCHandle dc, const weasel::Text& text, IDW
 	const std::wstring& preedit = text.str;
 	const std::vector<weasel::TextAttribute> &attrs = text.attributes;
 	CSize size(0, 0);
-	weasel::TextRange range;
-	for (size_t j = 0; j < attrs.size(); ++j)
-		if (attrs[j].type == weasel::HIGHLIGHTED)
-			range = attrs[j].range;
-	std::wstring before_str = preedit.substr(0, range.start);
-	std::wstring hilited_str = preedit.substr(range.start, range.end);
-	std::wstring after_str = preedit.substr(range.end);
-	CSize beforesz(0,0), hilitedsz(0,0), aftersz(0,0);
-	GetTextSizeDW(before_str, before_str.length(), pTextFormat, pDWR, &beforesz);
-	GetTextSizeDW(hilited_str, hilited_str.length(), pTextFormat, pDWR, &hilitedsz);
-	GetTextSizeDW(after_str, after_str.length(), pTextFormat, pDWR, &aftersz);
-	auto width_max = 0, height_max = 0;
-	if(_style.layout_type == UIStyle::LAYOUT_VERTICAL_TEXT)
+	if(!preedit.empty())
 	{
-		width_max = max(width_max, beforesz.cx);
-		width_max = max(width_max, hilitedsz.cx);
-		width_max = max(width_max, aftersz.cx);
-		height_max += beforesz.cy + (beforesz.cy > 0) * _style.hilite_spacing;
-		height_max += hilitedsz.cy + (hilitedsz.cy > 0) * _style.hilite_spacing;
-		height_max += aftersz.cy + (aftersz.cy > 0) * _style.hilite_spacing;
+		weasel::TextRange range;
+		for (size_t j = 0; j < attrs.size(); ++j)
+			if (attrs[j].type == weasel::HIGHLIGHTED)
+				range = attrs[j].range;
 		if(range.start < range.end)
-			height_max += 2 * _style.hilite_padding;
+		{
+			std::wstring before_str = preedit.substr(0, range.start);
+			std::wstring hilited_str = preedit.substr(range.start, range.end);
+			std::wstring after_str = preedit.substr(range.end);
+			CSize beforesz(0,0), hilitedsz(0,0), aftersz(0,0);
+			GetTextSizeDW(before_str, before_str.length(), pTextFormat, pDWR, &beforesz);
+			GetTextSizeDW(hilited_str, hilited_str.length(), pTextFormat, pDWR, &hilitedsz);
+			GetTextSizeDW(after_str, after_str.length(), pTextFormat, pDWR, &aftersz);
+			auto width_max = 0, height_max = 0;
+			if(_style.layout_type == UIStyle::LAYOUT_VERTICAL_TEXT)
+			{
+				width_max = max(width_max, beforesz.cx);
+				width_max = max(width_max, hilitedsz.cx);
+				width_max = max(width_max, aftersz.cx);
+				height_max += beforesz.cy + (beforesz.cy > 0) * _style.hilite_spacing;
+				height_max += hilitedsz.cy + (hilitedsz.cy > 0) * _style.hilite_spacing;
+				height_max += aftersz.cy; // + (aftersz.cy > 0) * _style.hilite_spacing;
+			}
+			else
+			{
+				height_max = max(height_max, beforesz.cy);
+				height_max = max(height_max, hilitedsz.cy);
+				height_max = max(height_max, aftersz.cy);
+				width_max += beforesz.cx + (beforesz.cx > 0) * _style.hilite_spacing;
+				width_max += hilitedsz.cx + (hilitedsz.cx > 0) * _style.hilite_spacing;
+				width_max += aftersz.cx ;// + (aftersz.cx > 0) * _style.hilite_spacing;
+			}
+			size.cx = width_max;
+			size.cy = height_max;
+		}
+		else
+			GetTextSizeDW(preedit, preedit.length(), pTextFormat, pDWR, &size);
 	}
-	else
-	{
-		height_max = max(height_max, beforesz.cy);
-		height_max = max(height_max, hilitedsz.cy);
-		height_max = max(height_max, aftersz.cy);
-		width_max += beforesz.cx + (beforesz.cx > 0) * _style.hilite_spacing;
-		width_max += hilitedsz.cx + (hilitedsz.cx > 0) * _style.hilite_spacing;
-		width_max += aftersz.cx + (aftersz.cx > 0) * _style.hilite_spacing;
-		if(range.start < range.end)
-			width_max += 2 * _style.hilite_padding;
-	}
-	size.cx = width_max;
-	size.cy = height_max;
 	return size;
 }
 

--- a/WeaselUI/VHorizontalLayout.cpp
+++ b/WeaselUI/VHorizontalLayout.cpp
@@ -30,8 +30,9 @@ void VHorizontalLayout::DoLayout(CDCHandle dc, DirectWriteResources* pDWR )
 	CSize pgszl, pgszr;
 	GetTextSizeDW(pre, pre.length(), pDWR->pPreeditTextFormat, pDWR, &pgszl);
 	GetTextSizeDW(next, next.length(), pDWR->pPreeditTextFormat, pDWR, &pgszr);
-	int pgh = pgszl.cy + pgszr.cy + _style.hilite_spacing + _style.hilite_padding * 2;
-	int pgw = max(pgszl.cx, pgszr.cx);
+	bool page_en = (_style.prevpage_color & 0xff000000) && (_style.nextpage_color & 0xff000000);
+	int pgh = page_en ? pgszl.cy + pgszr.cy + _style.hilite_spacing + _style.hilite_padding * 2 : 0;
+	int pgw = page_en ? max(pgszl.cx, pgszr.cx) : 0;
 
 	/* Preedit */
 	if (!IsInlinePreedit() && !_context.preedit.str.empty())
@@ -185,7 +186,7 @@ void VHorizontalLayout::DoLayout(CDCHandle dc, DirectWriteResources* pDWR )
 	_contentSize.SetSize(width + offsetX, height + offsetY);
 
 	// calc page indicator 
-	if(candidates_count && !_style.inline_preedit)
+	if(page_en && candidates_count && !_style.inline_preedit)
 	{
 		int _prey = _contentSize.cy - offsetY - real_margin_y + _style.hilite_padding - pgh;
 		int _prex = (_preeditRect.left + _preeditRect.right) / 2 - pgszl.cx / 2;
@@ -234,8 +235,9 @@ void VHorizontalLayout::DoLayoutWithWrap(CDCHandle dc, DirectWriteResources* pDW
 	CSize pgszl, pgszr;
 	GetTextSizeDW(pre, pre.length(), pDWR->pPreeditTextFormat, pDWR, &pgszl);
 	GetTextSizeDW(next, next.length(), pDWR->pPreeditTextFormat, pDWR, &pgszr);
-	int pgh = pgszl.cy + pgszr.cy + _style.hilite_spacing + _style.hilite_padding * 2;
-	int pgw = max(pgszl.cx, pgszr.cx);
+	bool page_en = (_style.prevpage_color & 0xff000000) && (_style.nextpage_color & 0xff000000);
+	int pgh = page_en ? pgszl.cy + pgszr.cy + _style.hilite_spacing + _style.hilite_padding * 2 : 0;
+	int pgw = page_en ? max(pgszl.cx, pgszr.cx) : 0;
 
 	/* Preedit */
 	if (!IsInlinePreedit() && !_context.preedit.str.empty())
@@ -427,7 +429,7 @@ void VHorizontalLayout::DoLayoutWithWrap(CDCHandle dc, DirectWriteResources* pDW
 	_contentRect.SetRect(0, 0, _contentSize.cx, _contentSize.cy);
 
 	// calc page indicator 
-	if(candidates_count && !_style.inline_preedit)
+	if(page_en && candidates_count && !_style.inline_preedit)
 	{
 		int _prey = _contentSize.cy - offsetY - real_margin_y + _style.hilite_padding - pgh;
 		int _prex = (_preeditRect.left + _preeditRect.right) / 2 - pgszl.cx / 2;

--- a/WeaselUI/VerticalLayout.cpp
+++ b/WeaselUI/VerticalLayout.cpp
@@ -65,7 +65,7 @@ void weasel::VerticalLayout::DoLayout(CDCHandle dc, DirectWriteResources* pDWR)
 			height += _style.candidate_spacing;
 
 		int w = real_margin_x + base_offset, max_height_curren_candidate = 0;
-		int candidate_width = 0, comment_width = 0;
+		int candidate_width = base_offset, comment_width = 0;
 		/* Label */
 		std::wstring label = GetLabelText(labels, i, _style.label_text_format.c_str());
 		GetTextSizeDW(label, label.length(), pDWR->pLabelTextFormat, pDWR, &size);

--- a/WeaselUI/VerticalLayout.cpp
+++ b/WeaselUI/VerticalLayout.cpp
@@ -22,8 +22,9 @@ void weasel::VerticalLayout::DoLayout(CDCHandle dc, DirectWriteResources* pDWR)
 	CSize pgszl, pgszr;
 	GetTextSizeDW(pre, pre.length(), pDWR->pPreeditTextFormat, pDWR, &pgszl);
 	GetTextSizeDW(next, next.length(), pDWR->pPreeditTextFormat, pDWR, &pgszr);
-	int pgw = pgszl.cx + pgszr.cx + _style.hilite_spacing + _style.hilite_padding * 2;
-	int pgh = max(pgszl.cy, pgszr.cy);
+	bool page_en = (_style.prevpage_color & 0xff000000) && (_style.nextpage_color & 0xff000000);
+	int pgw = page_en ? pgszl.cx + pgszr.cx + _style.hilite_spacing + _style.hilite_padding * 2 : 0;
+	int pgh = page_en ? max(pgszl.cy, pgszr.cy) : 0;
 
 	/*  preedit and auxiliary rectangle calc start */
 	CSize size;
@@ -64,7 +65,7 @@ void weasel::VerticalLayout::DoLayout(CDCHandle dc, DirectWriteResources* pDWR)
 			height += _style.candidate_spacing;
 
 		int w = real_margin_x + base_offset, max_height_curren_candidate = 0;
-		int candidate_width = w, comment_width = 0;
+		int candidate_width = 0, comment_width = 0;
 		/* Label */
 		std::wstring label = GetLabelText(labels, i, _style.label_text_format.c_str());
 		GetTextSizeDW(label, label.length(), pDWR->pLabelTextFormat, pDWR, &size);
@@ -163,7 +164,7 @@ void weasel::VerticalLayout::DoLayout(CDCHandle dc, DirectWriteResources* pDWR)
 
 	height += real_margin_y;
 
-	if (!_context.preedit.str.empty() && !candidates.empty())
+	if (!_context.preedit.str.empty() && candidates_count)
 	{
 		width = max(width, _style.min_width);
 		height = max(height, _style.min_height);
@@ -179,7 +180,7 @@ void weasel::VerticalLayout::DoLayout(CDCHandle dc, DirectWriteResources* pDWR)
 
 	_highlightRect = _candidateRects[id];
 	// calc page indicator 
-	if(candidates_count && !_style.inline_preedit)
+	if(page_en && candidates_count && !_style.inline_preedit)
 	{
 		int _prex = _contentSize.cx - offsetX - real_margin_x + _style.hilite_padding - pgw;
 		int _prey = (_preeditRect.top + _preeditRect.bottom) / 2 - pgszl.cy / 2;

--- a/WeaselUI/WeaselPanel.cpp
+++ b/WeaselUI/WeaselPanel.cpp
@@ -523,11 +523,13 @@ bool WeaselPanel::_DrawPreedit(Text const& text, CDCHandle dc, CRect const& rc)
 			CRect prc = m_layout->GetPrepageRect();
 			// clickable color / disabled color
 			int color = m_ctx.cinfo.currentPage ? m_style.prevpage_color : m_style.text_color;
+			if(m_istorepos)	prc.OffsetRect(0, m_offsety_preedit);
 			_TextOut(prc, pre.c_str(), pre.length(), color, txtFormat);
 
 			CRect nrc = m_layout->GetNextpageRect();
 			// clickable color / disabled color
 			color = m_ctx.cinfo.is_last_page ? m_style.text_color : m_style.nextpage_color;
+			if(m_istorepos)	nrc.OffsetRect(0, m_offsety_preedit);
 			_TextOut(nrc, next.c_str(), next.length(), color, txtFormat);
 		}
 		drawn = true;

--- a/WeaselUI/WeaselPanel.cpp
+++ b/WeaselUI/WeaselPanel.cpp
@@ -863,7 +863,7 @@ LRESULT WeaselPanel::OnDpiChanged(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL&
 void WeaselPanel::MoveTo(RECT const& rc)
 {
 	if(!m_layout)	return;			// avoid handling nullptr in _RepositionWindow 
-	if(CRect(rc) != m_oinputPos		// pos changed
+	if((rc.left != m_oinputPos.left && rc.bottom != m_oinputPos.bottom)		// pos changed
 		|| m_octx != m_ctx
 		|| (m_style.inline_preedit && m_ctx.preedit.str.empty() && (CRect(rc) == m_oinputPos))	// after disabled by ctrl+space, inline_preedit
 		|| !m_ctx.aux.str.empty()	// aux not empty, msg 

--- a/WeaselUI/WeaselPanel.cpp
+++ b/WeaselUI/WeaselPanel.cpp
@@ -868,8 +868,9 @@ void WeaselPanel::MoveTo(RECT const& rc)
 		|| (m_ctx.aux.empty() && (m_layout) && m_layout->ShouldDisplayStatusIcon()))	// ascii icon
 	{
 		m_octx = m_ctx;
-		m_oinputPos = rc;
 		m_inputPos = rc;
+		m_inputPos.OffsetRect(0, 6);
+		m_oinputPos = m_inputPos;
 		// with parameter to avoid vertical flicker
 		_RepositionWindow(true);
 		RedrawWindow();
@@ -897,34 +898,21 @@ void WeaselPanel::_RepositionWindow(bool adj)
 	rcWorkArea.bottom -= height;
 	int x = m_inputPos.left;
 	int y = m_inputPos.bottom;
-	if (m_style.shadow_radius > 0) {
-		x -= (m_style.shadow_offset_x >= 0) ? m_layout->offsetX : (COLORNOTTRANSPARENT(m_style.shadow_color)? 0 : (m_style.margin_x - m_style.hilite_padding));
-		// avoid flickering in MoveTo
-		if(adj) {
-			y -= (m_style.shadow_offset_y >= 0) ? m_layout->offsetY : (COLORNOTTRANSPARENT(m_style.shadow_color)? 0 : (m_style.margin_y - m_style.hilite_padding));
-			y -= m_style.shadow_radius / 2;
-		}
-	}
+	x -= (m_style.shadow_offset_x >= 0 || COLORTRANSPARENT(m_style.shadow_color)) ? m_layout->offsetX : (m_layout->offsetX / 2);
+	if(adj) y -= (m_style.shadow_offset_y >= 0 || COLORTRANSPARENT(m_style.shadow_color)) ? m_layout->offsetY : (m_layout->offsetY / 2);
 	// for vertical text layout, flow right to left, make window left side
-	if(m_style.layout_type == UIStyle::LAYOUT_VERTICAL_TEXT && !m_style.vertical_text_left_to_right) {
-		x -= width;
-		x += m_layout->offsetX;
-	}
+	if(m_style.layout_type == UIStyle::LAYOUT_VERTICAL_TEXT && !m_style.vertical_text_left_to_right)
+		x += m_layout->offsetX - width;
 	if(adj) m_istorepos = false;
 	if (x > rcWorkArea.right) x = rcWorkArea.right;		// over workarea right
 	if (x < rcWorkArea.left) x = rcWorkArea.left;		// over workarea left
 	// show panel above the input focus if we're around the bottom
-	if (y > rcWorkArea.bottom)
-	{
-		y = m_inputPos.top - height; // over workarea bottom
-		if (m_style.vertical_auto_reverse && m_style.layout_type == UIStyle::LAYOUT_VERTICAL)
-		{
-			m_istorepos = true;
-			if(m_style.shadow_radius > 0 && adj) {
-				y += (m_style.shadow_offset_y >= 0) ? m_layout->offsetY : (COLORNOTTRANSPARENT(m_style.shadow_color)? 0 : (m_style.margin_y - m_style.hilite_padding));
-				y += m_style.shadow_radius / 2;
-			}
-		}
+	if (y > rcWorkArea.bottom) {
+		y = m_inputPos.top - height - 6; // over workarea bottom
+		if( !adj && (y + height < m_oinputPos.top) )
+			y = m_oinputPos.top - height;
+		m_istorepos = (m_style.vertical_auto_reverse && m_style.layout_type == UIStyle::LAYOUT_VERTICAL);
+		y += (m_style.shadow_offset_y < 0 || COLORTRANSPARENT(m_style.shadow_color)) ? m_layout->offsetY : (m_layout->offsetY / 2);
 	}
 	if (y < rcWorkArea.top) y = rcWorkArea.top;		// over workarea top
 	// memorize adjusted position (to avoid window bouncing on height change)


### PR DESCRIPTION
修复一些界面问题
1. preedit 尺寸计算错误， #923 
2. prevpage_color和nextpage_color均为透明，而inline_preedit为false时，候选窗口尺寸计算偏大问题
3. vertical_auto_reverse设置后倒序排列时，翻页符位置不正确
4. vertical布局，当mark_text设置后，部分情况下发生字符超出背景色框
5. 一些软件偶发的光标位置y向1个像素波动引起的候选窗抖动情况发生  #913 
6. 避免inline_preedit时，候选框离输入字符位置太近的问题

改善
1.简化重调位置计算，保证在阴影可见的情况下候选窗口尽可能最接近输入位置又不会造成阴影遮盖输入区域文字