### PR TITLE
修复wezterm无法输入的问题

### DIFF
--- a/RimeWithWeasel/RimeWithWeasel.cpp
+++ b/RimeWithWeasel/RimeWithWeasel.cpp
@@ -842,6 +842,13 @@ static void _UpdateUIStyle(RimeConfig* config, weasel::UI* ui, bool initialize)
 	{
 		style.display_tray_icon = !!display_tray_icon;
 	}
+
+	Bool ascii_tip_follow_cursor = False;
+	if (RimeConfigGetBool(config, "style/ascii_tip_follow_cursor", &ascii_tip_follow_cursor) || initialize)
+	{
+		style.ascii_tip_follow_cursor = !!ascii_tip_follow_cursor;
+	}
+
 	Bool horizontal = False;
 	if (RimeConfigGetBool(config, "style/horizontal", &horizontal) || initialize)
 	{

--- a/WeaselSetup/WeaselSetup.cpp
+++ b/WeaselSetup/WeaselSetup.cpp
@@ -5,6 +5,8 @@
 #include "WeaselSetup.h"
 #include "InstallOptionsDialog.h"
 
+#include <ShellScalingApi.h>
+#pragma comment(lib, "Shcore.lib")
 CAppModule _Module;
 
 static int Run(LPTSTR lpCmdLine);
@@ -16,6 +18,7 @@ int APIENTRY _tWinMain(HINSTANCE hInstance,
 {
 	UNREFERENCED_PARAMETER(hPrevInstance);
 
+	SetProcessDpiAwareness(PROCESS_PER_MONITOR_DPI_AWARE);
 	HRESULT hRes = ::CoInitialize(NULL);
 	// If you are running on NT 4.0 or higher you can use the following call instead to
 	// make the EXE free threaded. This means that calls come in on a random RPC thread.

--- a/WeaselSetup/WeaselSetup.vcxproj
+++ b/WeaselSetup/WeaselSetup.vcxproj
@@ -89,6 +89,9 @@
       <OutputFile>$(SolutionDir)output\$(ProjectName)$(TargetExt)</OutputFile>
       <UACExecutionLevel>RequireAdministrator</UACExecutionLevel>
     </Link>
+    <Manifest>
+      <EnableDpiAwareness>PerMonitorHighDPIAware</EnableDpiAwareness>
+    </Manifest>
   </ItemDefinitionGroup>
   <ItemGroup>
     <None Include="ReadMe.txt" />

--- a/WeaselTSF/Register.cpp
+++ b/WeaselTSF/Register.cpp
@@ -89,74 +89,61 @@ void UnregisterProfiles()
 
 }
 
+const GUID SupportCategories0[] =
+{
+	 GUID_TFCAT_CATEGORY_OF_TIP,
+	 GUID_TFCAT_TIP_KEYBOARD,
+	 // GUID_TFCAT_TIP_SPEECH,
+	 // GUID_TFCAT_TIP_HANDWRITING,
+	 GUID_TFCAT_TIPCAP_SECUREMODE,
+	 GUID_TFCAT_TIPCAP_UIELEMENTENABLED,
+	 GUID_TFCAT_TIPCAP_INPUTMODECOMPARTMENT,
+	 GUID_TFCAT_TIPCAP_COMLESS,
+	 GUID_TFCAT_TIPCAP_WOW16,
+	 GUID_TFCAT_TIPCAP_IMMERSIVESUPPORT,
+	 GUID_TFCAT_TIPCAP_SYSTRAYSUPPORT,
+	 GUID_TFCAT_PROP_AUDIODATA,
+	 GUID_TFCAT_PROP_INKDATA,
+	 GUID_TFCAT_PROPSTYLE_CUSTOM,
+	 GUID_TFCAT_PROPSTYLE_STATIC,
+	 GUID_TFCAT_PROPSTYLE_STATICCOMPACT,
+	 GUID_TFCAT_DISPLAYATTRIBUTEPROVIDER,
+	 GUID_TFCAT_DISPLAYATTRIBUTEPROPERTY
+};
+
 BOOL RegisterCategories()
 {
-	ITfCategoryMgr *pCategoryMgr;
+	ITfCategoryMgr* pCategoryMgr;
 	HRESULT hr;
 
-	hr = CoCreateInstance(CLSID_TF_CategoryMgr, NULL, CLSCTX_INPROC_SERVER, IID_ITfCategoryMgr, (void **)&pCategoryMgr);
+	hr = CoCreateInstance(CLSID_TF_CategoryMgr, NULL, CLSCTX_INPROC_SERVER, IID_ITfCategoryMgr, (void**)&pCategoryMgr);
 	if (hr != S_OK)
 		return FALSE;
 
-	hr = pCategoryMgr->RegisterCategory(c_clsidTextService, GUID_TFCAT_TIP_KEYBOARD, c_clsidTextService);
-	if (hr != S_OK)
-		goto Exit;
+	BOOL flag = TRUE;
+	for (const auto& guid : SupportCategories0)
+	{
+		hr = pCategoryMgr->RegisterCategory(c_clsidTextService, guid, c_clsidTextService);
+		if (hr != S_OK)
+			flag = FALSE;
+	}
 
-	hr = pCategoryMgr->RegisterCategory(c_clsidTextService, GUID_TFCAT_TIPCAP_UIELEMENTENABLED, c_clsidTextService);
-	if (hr != S_OK)
-		goto Exit;
-
-	hr = pCategoryMgr->RegisterCategory(c_clsidTextService, GUID_TFCAT_TIPCAP_INPUTMODECOMPARTMENT, c_clsidTextService);
-	if (hr != S_OK)
-		goto Exit;
-
-	hr = pCategoryMgr->RegisterCategory(c_clsidTextService, GUID_TFCAT_DISPLAYATTRIBUTEPROVIDER, c_clsidTextService);
-	if (hr != S_OK)
-		goto Exit;
-
-	hr = pCategoryMgr->RegisterCategory(c_clsidTextService, GUID_TFCAT_TIPCAP_IMMERSIVESUPPORT, c_clsidTextService);
-	if (hr != S_OK)
-		goto Exit;
-
-	hr = pCategoryMgr->RegisterCategory(c_clsidTextService, GUID_TFCAT_TIPCAP_SYSTRAYSUPPORT, c_clsidTextService);
-
-Exit:
 	pCategoryMgr->Release();
-	return (hr == S_OK);
+	return flag;
 }
 
 void UnregisterCategories()
 {
-	ITfCategoryMgr *pCategoryMgr;
+	ITfCategoryMgr* pCategoryMgr;
 	HRESULT hr;
 
-	hr = CoCreateInstance(CLSID_TF_CategoryMgr, NULL, CLSCTX_INPROC_SERVER, IID_ITfCategoryMgr, (void **)&pCategoryMgr);
+	hr = CoCreateInstance(CLSID_TF_CategoryMgr, NULL, CLSCTX_INPROC_SERVER, IID_ITfCategoryMgr, (void**)&pCategoryMgr);
 	if (FAILED(hr))
 		return;
 
-	hr = pCategoryMgr->UnregisterCategory(c_clsidTextService, GUID_TFCAT_TIP_KEYBOARD, c_clsidTextService);
-	if (hr != S_OK)
-		goto UnregisterExit;
+	for (const auto& guid : SupportCategories0)
+		pCategoryMgr->UnregisterCategory(c_clsidTextService, guid, c_clsidTextService);
 
-	hr = pCategoryMgr->UnregisterCategory(c_clsidTextService, GUID_TFCAT_TIPCAP_UIELEMENTENABLED, c_clsidTextService);
-	if (hr != S_OK)
-		goto UnregisterExit;
-
-	hr = pCategoryMgr->UnregisterCategory(c_clsidTextService, GUID_TFCAT_TIPCAP_INPUTMODECOMPARTMENT, c_clsidTextService);
-	if (hr != S_OK)
-		goto UnregisterExit;
-
-	hr = pCategoryMgr->UnregisterCategory(c_clsidTextService, GUID_TFCAT_DISPLAYATTRIBUTEPROVIDER, c_clsidTextService);
-	if (hr != S_OK)
-		goto UnregisterExit;
-
-	hr = pCategoryMgr->UnregisterCategory(c_clsidTextService, GUID_TFCAT_TIPCAP_IMMERSIVESUPPORT, c_clsidTextService);
-	if (hr != S_OK)
-		goto UnregisterExit;
-
-	hr = pCategoryMgr->UnregisterCategory(c_clsidTextService, GUID_TFCAT_TIPCAP_SYSTRAYSUPPORT, c_clsidTextService);
-
-UnregisterExit:
 	pCategoryMgr->Release();
 }
 

--- a/WeaselTSF/WeaselTSF.cpp
+++ b/WeaselTSF/WeaselTSF.cpp
@@ -142,8 +142,10 @@ STDAPI WeaselTSF::ActivateEx(ITfThreadMgr *pThreadMgr, TfClientId tfClientId, DW
 	if (!_InitKeyEventSink())
 		goto ExitError;
 
-	if (!_InitDisplayAttributeGuidAtom())
-		goto ExitError;
+	//if (!_InitDisplayAttributeGuidAtom())
+	//	goto ExitError;
+	//	some app might init failed because it not provide DisplayAttributeInfo, like  some opengl stuff
+	_InitDisplayAttributeGuidAtom();
 
 	if (!_InitPreservedKey())
 		goto ExitError;

--- a/WeaselUI/WeaselPanel.cpp
+++ b/WeaselUI/WeaselPanel.cpp
@@ -863,6 +863,17 @@ LRESULT WeaselPanel::OnDpiChanged(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL&
 void WeaselPanel::MoveTo(RECT const& rc)
 {
 	if(!m_layout)	return;			// avoid handling nullptr in _RepositionWindow 
+	// if ascii_tip_follow_cursor set, move tip icon to mouse cursor
+	if(m_style.ascii_tip_follow_cursor && m_ctx.aux.empty() && (m_layout) && m_layout->ShouldDisplayStatusIcon())	// ascii icon
+	{
+		POINT p;
+		::GetCursorPos(&p);
+		RECT irc{p.x-STATUS_ICON_SIZE, p.y-STATUS_ICON_SIZE, p.x, p.y};
+		m_inputPos = irc;
+		m_oinputPos = irc;
+		_RepositionWindow(true);
+		RedrawWindow();
+	} else 
 	if((rc.left != m_oinputPos.left && rc.bottom != m_oinputPos.bottom)		// pos changed
 		|| m_octx != m_ctx
 		|| (m_style.inline_preedit && m_ctx.preedit.str.empty() && (CRect(rc) == m_oinputPos))	// after disabled by ctrl+space, inline_preedit

--- a/WeaselUI/WeaselPanel.cpp
+++ b/WeaselUI/WeaselPanel.cpp
@@ -904,7 +904,10 @@ void WeaselPanel::_RepositionWindow(bool adj)
 	if(adj) y -= (m_style.shadow_offset_y >= 0 || COLORTRANSPARENT(m_style.shadow_color)) ? m_layout->offsetY : (m_layout->offsetY / 2);
 	// for vertical text layout, flow right to left, make window left side
 	if(m_style.layout_type == UIStyle::LAYOUT_VERTICAL_TEXT && !m_style.vertical_text_left_to_right)
+	{
 		x += m_layout->offsetX - width;
+		if ( m_style.shadow_offset_x < 0 ) x += m_layout->offsetX;
+	}
 	if(adj) m_istorepos = false;
 	if (x > rcWorkArea.right) x = rcWorkArea.right;		// over workarea right
 	if (x < rcWorkArea.left) x = rcWorkArea.left;		// over workarea left

--- a/include/WeaselCommon.h
+++ b/include/WeaselCommon.h
@@ -287,6 +287,7 @@ namespace weasel
 		int comment_font_point;
 		bool inline_preedit;
 		bool display_tray_icon;
+		bool ascii_tip_follow_cursor;
 		std::wstring current_zhung_icon;
 		std::wstring current_ascii_icon;
 		bool enhanced_position;
@@ -348,6 +349,7 @@ namespace weasel
 			align_type(ALIGN_BOTTOM),
 			preedit_type(COMPOSITION),
 			display_tray_icon(false),
+			ascii_tip_follow_cursor(false),
 			current_zhung_icon(),
 			current_ascii_icon(),
 			enhanced_position(false),
@@ -416,6 +418,7 @@ namespace weasel
 					|| inline_preedit != st.inline_preedit
 					|| mark_text != st.mark_text
 					|| display_tray_icon != st.display_tray_icon
+					|| ascii_tip_follow_cursor != st.ascii_tip_follow_cursor
 					|| current_zhung_icon != st.current_zhung_icon
 					|| current_ascii_icon != st.current_ascii_icon
 					|| enhanced_position != st.enhanced_position
@@ -480,6 +483,7 @@ namespace boost {
 			ar & s.mark_text;
 			ar & s.preedit_type;
 			ar & s.display_tray_icon;
+			ar & s.ascii_tip_follow_cursor;
 			ar & s.current_zhung_icon;
 			ar & s.current_ascii_icon;
 			ar& s.enhanced_position;

--- a/output/data/weasel.yaml
+++ b/output/data/weasel.yaml
@@ -11,6 +11,7 @@ app_options:
 
 style:
   antialias_mode: default
+  ascii_tip_follow_cursor: false
   color_scheme: aqua
   font_face: Microsoft YaHei
   label_font_face: Microsoft YaHei


### PR DESCRIPTION
* fixed: weasel not work with wezterm in gpu mode.  #863 , maybe more.
* ui enhancement: WeaselSetup dpi per monitor aware.
* ui enhancement: x position more close to input pos when vertical text right to left with shadow_offset_x negative value.
* feat: new bool type parameter `style/ascii_tip_follow_cursor: bool`, allow to configure if ascii tip follow mouse cursor

thanks great helps by @Techince 

![KG)RGJM}O RS}JSVZ~6}BW](https://github.com/rime/weasel/assets/4023160/29043f36-eae8-446a-8738-3aed63e1a619)
![ascii_tip_follow_cursor](https://github.com/rime/weasel/assets/4023160/9dcbf6d8-0338-45b8-8773-e7354a8b839e)
