### PR TITLE
fixed: in some case, candidate window position not correct when window above input position

### DIFF
--- a/WeaselUI/WeaselPanel.cpp
+++ b/WeaselUI/WeaselPanel.cpp
@@ -75,8 +75,8 @@ WeaselPanel::~WeaselPanel()
 void WeaselPanel::_ResizeWindow()
 {
 	CDCHandle dc = GetDC();
-	CSize size = m_layout->GetContentSize();
-	SetWindowPos(NULL, 0, 0, size.cx, size.cy, SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOZORDER | SWP_NOREDRAW);
+	m_size = m_layout->GetContentSize();
+	SetWindowPos(NULL, 0, 0, m_size.cx, m_size.cy, SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOZORDER | SWP_NOREDRAW);
 	ReleaseDC(dc);
 }
 
@@ -874,13 +874,15 @@ void WeaselPanel::MoveTo(RECT const& rc)
 		_RepositionWindow(true);
 		RedrawWindow();
 	} else 
-	if((rc.left != m_oinputPos.left && rc.bottom != m_oinputPos.bottom)		// pos changed
+	if((rc.left != m_oinputPos.left && abs(rc.bottom - m_oinputPos.bottom) > 2)		// pos changed
+		|| m_size != m_osize
 		|| m_octx != m_ctx
 		|| (m_style.inline_preedit && m_ctx.preedit.str.empty() && (CRect(rc) == m_oinputPos))	// after disabled by ctrl+space, inline_preedit
 		|| !m_ctx.aux.str.empty()	// aux not empty, msg 
 		|| (m_ctx.aux.empty() && (m_layout) && m_layout->ShouldDisplayStatusIcon()))	// ascii icon
 	{
 		m_octx = m_ctx;
+		m_osize = m_size;
 		m_inputPos = rc;
 		m_inputPos.OffsetRect(0, 6);
 		m_oinputPos = m_inputPos;

--- a/WeaselUI/WeaselPanel.cpp
+++ b/WeaselUI/WeaselPanel.cpp
@@ -874,7 +874,7 @@ void WeaselPanel::MoveTo(RECT const& rc)
 		_RepositionWindow(true);
 		RedrawWindow();
 	} else 
-	if((rc.left != m_oinputPos.left && abs(rc.bottom - m_oinputPos.bottom) > 2)		// pos changed
+	if((rc.left != m_oinputPos.left && rc.bottom != m_oinputPos.bottom)		// pos changed
 		|| m_size != m_osize
 		|| m_octx != m_ctx
 		|| (m_style.inline_preedit && m_ctx.preedit.str.empty() && (CRect(rc) == m_oinputPos))	// after disabled by ctrl+space, inline_preedit

--- a/WeaselUI/WeaselPanel.h
+++ b/WeaselUI/WeaselPanel.h
@@ -95,6 +95,7 @@ private:
 	int  m_offsety_preedit;
 	int  m_offsety_aux;
 	bool m_istorepos;
+	CSize m_size;
 	CSize m_osize;
 
 	CIcon m_iconDisabled;


### PR DESCRIPTION
* in some case, candidate window position not correct when window above input position

![image](https://github.com/rime/weasel/assets/4023160/4fd9fa85-d9b6-4d4c-9e36-a435ef8d12f8)
