### PR TITLE
UI bug修复，单实例运行，防止主要文字透明

### DIFF
--- a/WeaselServer/WeaselServer.cpp
+++ b/WeaselServer/WeaselServer.cpp
@@ -66,14 +66,14 @@ int WINAPI _tWinMain(HINSTANCE hInstance, HINSTANCE /*hPrevInstance*/, LPTSTR lp
 	// command line option /q stops the running server
 	bool quit = !wcscmp(L"/q", lpstrCmdLine) || !wcscmp(L"/quit", lpstrCmdLine);
 	// restart if already running
+	if(quit)
 	{
 		weasel::Client client;
 		if (client.Connect())  // try to connect to running server
 		{
 			client.ShutdownServer();
 		}
-		if (quit)
-			return 0;
+		return 0;
 	}
 
 	bool check_updates = !wcscmp(L"/update", lpstrCmdLine);
@@ -85,7 +85,13 @@ int WINAPI _tWinMain(HINSTANCE hInstance, HINSTANCE /*hPrevInstance*/, LPTSTR lp
 	CreateDirectory(WeaselUserDataPath().c_str(), NULL);
 
 	int nRet = 0;
-
+	// named mutex to ensure only one instance running
+    HANDLE hMutex = CreateMutex(NULL, FALSE, L"WeaselServerNamedMutex");
+    if (GetLastError() == ERROR_ALREADY_EXISTS) {
+        CloseHandle(hMutex);
+		::MessageBox(NULL, L"已有算法服务實例正在運行", L"已有算法服务實例正在運行", MB_ICONINFORMATION);
+		return 0;
+	}
 	try
 	{
 		WeaselServerApp app;
@@ -101,5 +107,6 @@ int WINAPI _tWinMain(HINSTANCE hInstance, HINSTANCE /*hPrevInstance*/, LPTSTR lp
 	_Module.Term();
 	::CoUninitialize();
 
+	CloseHandle(hMutex);
 	return nRet;
 }

--- a/WeaselUI/WeaselPanel.cpp
+++ b/WeaselUI/WeaselPanel.cpp
@@ -877,7 +877,7 @@ void WeaselPanel::MoveTo(RECT const& rc)
 	if((rc.left != m_oinputPos.left && rc.bottom != m_oinputPos.bottom)		// pos changed
 		|| m_size != m_osize
 		|| m_octx != m_ctx
-		|| (m_style.inline_preedit && m_ctx.preedit.str.empty() && (CRect(rc) == m_oinputPos))	// after disabled by ctrl+space, inline_preedit
+		|| (m_ctx.preedit.str.empty() && (CRect(rc) == m_oinputPos))		// first click old pos
 		|| !m_ctx.aux.str.empty()	// aux not empty, msg 
 		|| (m_ctx.aux.empty() && (m_layout) && m_layout->ShouldDisplayStatusIcon()))	// ascii icon
 	{

--- a/WeaselUI/WeaselPanel.h
+++ b/WeaselUI/WeaselPanel.h
@@ -42,7 +42,7 @@ public:
 	END_MSG_MAP()
 
 	LRESULT OnCreate(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
-	LRESULT OnDestroy(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled) { return 0; };
+	LRESULT OnDestroy(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled) { m_osize = {0,0}; return 0; };
 	LRESULT OnDpiChanged(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
 #ifdef USE_MOUSE_EVENTS
 	LRESULT OnMouseActivate(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);


### PR DESCRIPTION
1. 修复 #913 中提及的firefox问题
2. 通过named mutex实现单实例运行，潜在可能解决#926 中双启动项引起的自启失败问题
3. 预防主要文字透明异常发生 在 #730 中提及的候选文字透明问题

![image](https://github.com/rime/weasel/assets/4023160/324aaac0-e09f-42e6-af33-c46755af6d40)
![image](https://user-images.githubusercontent.com/16448332/244908252-c8e3ec61-a5d4-4fd4-995a-0a269dbe1048.gif)
![image](https://user-images.githubusercontent.com/71162630/246575700-7be11c31-a98e-4ee0-958f-cf1049359e7d.png)