### PR TITLE
鼠标操作响应改善

### DIFF
--- a/RimeWithWeasel/RimeWithWeasel.cpp
+++ b/RimeWithWeasel/RimeWithWeasel.cpp
@@ -806,6 +806,7 @@ static void _UpdateUIStyle(RimeConfig* config, UI* ui, bool initialize)
 		style.font_point = 12;
 	_RimeGetIntWithFallback(config, "style/label_font_point", &style.label_font_point, "style/font_point", _abs);
 	_RimeGetIntWithFallback(config, "style/comment_font_point", &style.comment_font_point, "style/font_point", _abs);
+	_RimeGetIntWithFallback(config, "style/mouse_hover_ms", &style.mouse_hover_ms, NULL, _abs);
 	_RimeGetBool(config, "style/inline_preedit", initialize, style.inline_preedit, true, false);
 	_RimeGetBool(config, "style/vertical_auto_reverse", initialize, style.vertical_auto_reverse, true, false);
 	const std::map<std::string, UIStyle::PreeditType> _preeditMap = { 

--- a/RimeWithWeasel/RimeWithWeasel.cpp
+++ b/RimeWithWeasel/RimeWithWeasel.cpp
@@ -199,6 +199,14 @@ void RimeWithWeaselHandler::ClearComposition(UINT session_id)
 	m_active_session = session_id;
 }
 
+void RimeWithWeaselHandler::SelectCandidateOnCurrentPage(size_t index, UINT session_id)
+{
+	DLOG(INFO) << "select candidate on current page, session_id = " << session_id << ", index = " << index;
+	if (m_disabled) return;
+	RimeApi* api = rime_get_api();
+	api->select_candidate_on_current_page(session_id, index);
+}
+
 void RimeWithWeaselHandler::FocusIn(DWORD client_caps, UINT session_id)
 {
 	DLOG(INFO) << "Focus in: session_id = " << session_id << ", client_caps = " << client_caps;

--- a/RimeWithWeasel/RimeWithWeasel.cpp
+++ b/RimeWithWeasel/RimeWithWeasel.cpp
@@ -832,6 +832,7 @@ static void _UpdateUIStyle(RimeConfig* config, UI* ui, bool initialize)
 	_RimeGetBool(config, "style/display_tray_icon", initialize, style.display_tray_icon, true, false);
 	_RimeGetBool(config, "style/ascii_tip_follow_cursor", initialize, style.ascii_tip_follow_cursor, true, false);
 	_RimeGetBool(config, "style/horizontal", initialize, style.layout_type, UIStyle::LAYOUT_HORIZONTAL, UIStyle::LAYOUT_VERTICAL);
+	_RimeGetBool(config, "style/paging_on_scroll", initialize, style.paging_on_scroll, true, false);
 	_RimeGetBool(config, "style/fullscreen", false, style.layout_type, 
 			((style.layout_type == UIStyle::LAYOUT_HORIZONTAL) ? UIStyle::LAYOUT_HORIZONTAL_FULLSCREEN : UIStyle::LAYOUT_VERTICAL_FULLSCREEN), style.layout_type);
 	_RimeGetBool(config, "style/vertical_text", false, style.layout_type, UIStyle::LAYOUT_VERTICAL_TEXT, style.layout_type);

--- a/WeaselIPC/WeaselClientImpl.cpp
+++ b/WeaselIPC/WeaselClientImpl.cpp
@@ -93,6 +93,14 @@ bool ClientImpl::ClearComposition()
 	return ret != 0;
 }
 
+bool ClientImpl::SelectCandidateOnCurrentPage(size_t index)
+{
+	if(!_Active())
+		return false;
+	LRESULT ret = _SendMessage(WEASEL_IPC_SELECT_CANDIDATE_ON_CURRENT_PAGE, index, session_id);
+	return ret != 0;
+}
+
 void ClientImpl::UpdateInputPosition(RECT const& rc)
 {
 	if (!_Active())
@@ -242,6 +250,11 @@ bool Client::CommitComposition()
 bool Client::ClearComposition()
 {
 	return m_pImpl->ClearComposition();
+}
+
+bool Client::SelectCandidateOnCurrentPage(size_t index)
+{
+	return m_pImpl->SelectCandidateOnCurrentPage(index);
 }
 
 void Client::UpdateInputPosition(RECT const& rc)

--- a/WeaselIPC/WeaselClientImpl.h
+++ b/WeaselIPC/WeaselClientImpl.h
@@ -22,6 +22,7 @@ namespace weasel
 		bool ProcessKeyEvent(KeyEvent const& keyEvent);
 		bool CommitComposition();
 		bool ClearComposition();
+		bool SelectCandidateOnCurrentPage(size_t index);
 		void UpdateInputPosition(RECT const& rc);
 		void FocusIn();
 		void FocusOut();

--- a/WeaselIPCServer/WeaselServerImpl.cpp
+++ b/WeaselIPCServer/WeaselServerImpl.cpp
@@ -301,6 +301,13 @@ DWORD ServerImpl::OnClearComposition(WEASEL_IPC_COMMAND uMsg, DWORD wParam, DWOR
 	return 0;
 }
 
+DWORD ServerImpl::OnSelectCandidateOnCurrentPage(WEASEL_IPC_COMMAND uMsg, DWORD wParam, DWORD lParam)
+{
+	if(m_pRequestHandler)
+		m_pRequestHandler->SelectCandidateOnCurrentPage(wParam, lParam);
+	return 0;
+}
+
 #define MAP_PIPE_MSG_HANDLE(__msg, __wParam, __lParam) {\
 auto lParam = __lParam;\
 auto wParam = __wParam;\
@@ -332,6 +339,7 @@ void ServerImpl::HandlePipeMessage(PipeMessage pipe_msg, _Resp resp)
 		PIPE_MSG_HANDLE(WEASEL_IPC_END_MAINTENANCE, OnEndMaintenance)
 		PIPE_MSG_HANDLE(WEASEL_IPC_COMMIT_COMPOSITION, OnCommitComposition)
 		PIPE_MSG_HANDLE(WEASEL_IPC_CLEAR_COMPOSITION, OnClearComposition);
+		PIPE_MSG_HANDLE(WEASEL_IPC_SELECT_CANDIDATE_ON_CURRENT_PAGE, OnSelectCandidateOnCurrentPage);
 		PIPE_MSG_HANDLE(WEASEL_IPC_TRAY_COMMAND, OnCommand);
 	END_MAP_PIPE_MSG_HANDLE(result);
 

--- a/WeaselIPCServer/WeaselServerImpl.h
+++ b/WeaselIPCServer/WeaselServerImpl.h
@@ -49,6 +49,7 @@ namespace weasel
 		DWORD OnEndMaintenance(WEASEL_IPC_COMMAND uMsg, DWORD wParam, DWORD lParam);
 		DWORD OnCommitComposition(WEASEL_IPC_COMMAND uMsg, DWORD wParam, DWORD lParam);
 		DWORD OnClearComposition(WEASEL_IPC_COMMAND uMsg, DWORD wParam, DWORD lParam);
+		DWORD OnSelectCandidateOnCurrentPage(WEASEL_IPC_COMMAND uMsg, DWORD wParam, DWORD lParam);
 
 	public:
 		ServerImpl();

--- a/WeaselTSF/CandidateList.cpp
+++ b/WeaselTSF/CandidateList.cpp
@@ -430,7 +430,19 @@ void WeaselTSF::_HandleMousePageEvent(const bool nextPage)
 {
 	// ToDo: if feature new api comes, replace the processes bellow
 	weasel::KeyEvent ke{ 0, 0 };
-	ke.keycode = nextPage ? ibus::Page_Down : ibus::Page_Up;
+	if(_cand->style().paging_on_scroll)
+		ke.keycode = nextPage ? ibus::Page_Down : ibus::Page_Up;
+	else
+	{
+		ke.keycode = nextPage ? ibus::Down : ibus::Up;
+		if(_cand->GetIsReposition())
+		{
+			if(ke.keycode == ibus::Up)
+				ke.keycode = ibus::Down;
+			else if(ke.keycode == ibus::Down)
+				ke.keycode = ibus::Up;
+		}
+	}
 	m_client.ProcessKeyEvent(ke);
 	DoEditSession(0);
 }

--- a/WeaselTSF/CandidateList.cpp
+++ b/WeaselTSF/CandidateList.cpp
@@ -325,6 +325,8 @@ void CCandidateList::StartUI()
 		return;
 	}
 
+	_ui->SetSelectCallback([this](const std::wstring str, const size_t index) { _tsf->InsertText(str, index); });
+	// ToDo: send select candidate info back to rime
 	pUIElementMgr->BeginUIElement(this, &_pbShow, &uiid);
 	//pUIElementMgr->UpdateUIElement(uiid);
 	if (_pbShow)
@@ -411,4 +413,13 @@ com_ptr<ITfContext> WeaselTSF::_GetUIContextDocument()
 void WeaselTSF::_DeleteCandidateList()
 {
 	_cand->Destroy();
+}
+
+void WeaselTSF::InsertText(const std::wstring& wstr, size_t index)
+{
+	_InsertText(_pEditSessionContext, wstr);
+	_EndComposition(_pEditSessionContext, false);
+	m_client.SelectCandidateOnCurrentPage(index);
+	// fake a presskey
+	m_client.ProcessKeyEvent(0);
 }

--- a/WeaselTSF/CandidateList.h
+++ b/WeaselTSF/CandidateList.h
@@ -54,6 +54,7 @@ public:
 	void EndUI();
 
 	com_ptr<ITfContext> GetContextDocument();
+	bool GetIsReposition(){ if(_ui) return _ui->GetIsReposition(); else return false; }
 
 	weasel::UIStyle &style();
 

--- a/WeaselTSF/KeyEventSink.cpp
+++ b/WeaselTSF/KeyEventSink.cpp
@@ -2,6 +2,7 @@
 #include "WeaselIPC.h"
 #include "WeaselTSF.h"
 #include "KeyEvent.h"
+#include "CandidateList.h"
 
 void WeaselTSF::_ProcessKeyEvent(WPARAM wParam, LPARAM lParam, BOOL *pfEaten)
 {
@@ -18,6 +19,14 @@ void WeaselTSF::_ProcessKeyEvent(WPARAM wParam, LPARAM lParam, BOOL *pfEaten)
 	}
 	else
     {
+		// cheet key code when vertical auto reverse happened, swap up and down
+		if(_cand->GetIsReposition())
+		{
+			if(ke.keycode == ibus::Up)
+				ke.keycode = ibus::Down;
+			else if(ke.keycode == ibus::Down)
+				ke.keycode = ibus::Up;
+		}
 		*pfEaten = (BOOL) m_client.ProcessKeyEvent(ke);
     }
 }

--- a/WeaselTSF/WeaselTSF.h
+++ b/WeaselTSF/WeaselTSF.h
@@ -118,9 +118,13 @@ public:
 
 
 	com_ptr<ITfThreadMgr> _GetThreadMgr() { return _pThreadMgr; }
-	void InsertText(const std::wstring& wstr, size_t index);
+	void HandleUICallback(size_t* const sel, size_t* const hov, bool* const next);
 
 private:
+	/* ui callback functions private */
+	void _SelectCandidateOnCurrentPage(const size_t index);
+	void _HandleMouseHoverEvent(const size_t index);
+	void _HandleMousePageEvent(const bool nextPage);
 	/* TSF Related */
 	BOOL _InitThreadMgrEventSink();
 	void _UninitThreadMgrEventSink();

--- a/WeaselTSF/WeaselTSF.h
+++ b/WeaselTSF/WeaselTSF.h
@@ -118,6 +118,7 @@ public:
 
 
 	com_ptr<ITfThreadMgr> _GetThreadMgr() { return _pThreadMgr; }
+	void InsertText(const std::wstring& wstr, size_t index);
 
 private:
 	/* TSF Related */

--- a/WeaselUI/DirectWriteResources.cpp
+++ b/WeaselUI/DirectWriteResources.cpp
@@ -34,7 +34,7 @@ std::vector<std::wstring> wc_split(const wchar_t* in, const wchar_t* delim)
 	};
 }
 
-DirectWriteResources::DirectWriteResources(weasel::UIStyle& style, UINT dpi = 0) :
+DirectWriteResources::DirectWriteResources(weasel::UIStyle& style, UINT dpi = 96) :
 	_style(style),
 	dpiScaleX_(0),
 	dpiScaleY_(0),
@@ -67,17 +67,9 @@ DirectWriteResources::DirectWriteResources(weasel::UIStyle& style, UINT dpi = 0)
 	}
 	pRenderTarget->CreateSolidColorBrush(D2D1::ColorF(1.0f, 1.0f, 1.0f, 1.0f), pBrush.GetAddressOf());
 	//get the dpi information
-	if (dpi == 0)
-	{
-		pD2d1Factory->GetDesktopDpi(&dpiScaleX_, &dpiScaleY_);
-		dpiScaleX_ /= 72.0f;
-		dpiScaleY_ /= 72.0f;
-	}
-	else
-	{
-		dpiScaleX_ = dpi / 72.0f;
-		dpiScaleY_ = dpi / 72.0f;
-	}
+	dpiScaleX_ = dpiScaleY_ = dpi;
+	dpiScaleX_ /= 72.0f;
+	dpiScaleY_ /= 72.0f;
 
 	InitResources(style, dpi);
 }
@@ -214,7 +206,7 @@ HRESULT DirectWriteResources::InitResources(std::wstring label_font_face, int la
 	return hResult;
 }
 
-HRESULT DirectWriteResources::InitResources(UIStyle& style, UINT dpi = 0)
+HRESULT DirectWriteResources::InitResources(UIStyle& style, UINT dpi = 96)
 {
 	_style = style;
 	if(dpi)

--- a/WeaselUI/StandardLayout.h
+++ b/WeaselUI/StandardLayout.h
@@ -8,7 +8,7 @@
 
 namespace weasel
 {
-	const int MAX_CANDIDATES_COUNT = 10;
+	const int MAX_CANDIDATES_COUNT = 100;
 	const int STATUS_ICON_SIZE = GetSystemMetrics(SM_CXICON);
 
 	class StandardLayout: public Layout

--- a/WeaselUI/WeaselPanel.cpp
+++ b/WeaselUI/WeaselPanel.cpp
@@ -161,7 +161,6 @@ void WeaselPanel::_InitFontRes(void)
 	dpi = dpiX;
 }
 
-#ifdef USE_MOUSE_EVENTS
 static HBITMAP CopyDCToBitmap(HDC hDC, LPRECT lpRect)
 {
 	if (!hDC || !lpRect || IsRectEmpty(lpRect)) return NULL;
@@ -289,9 +288,9 @@ LRESULT WeaselPanel::OnLeftClicked(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL
 	return 0;
 }
 
-#ifdef USE_MOUSE_HOVER
 LRESULT WeaselPanel::OnMouseHover(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
+	if(!m_style.mouse_hover_ms) return 0;
 	CPoint point;
 	point.x = GET_X_LPARAM(lParam);
 	point.y = GET_Y_LPARAM(lParam);
@@ -312,12 +311,12 @@ LRESULT WeaselPanel::OnMouseHover(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL&
 
 LRESULT WeaselPanel::OnMouseMove(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
-	if (m_mouse_entry == false)
+	if (m_mouse_entry == false && m_style.mouse_hover_ms)
 	{
 		TRACKMOUSEEVENT tme;
 		tme.cbSize = sizeof(TRACKMOUSEEVENT);
 		tme.dwFlags = TME_HOVER | TME_LEAVE;
-		tme.dwHoverTime = 400; // 400 ms 
+		tme.dwHoverTime = m_style.mouse_hover_ms; // unit: ms 
 		tme.hwndTrack = m_hWnd;
 		TrackMouseEvent(&tme);
 	}
@@ -329,8 +328,6 @@ LRESULT WeaselPanel::OnMouseLeave(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL&
 	m_mouse_entry = false;
 	return 0;
 }
-#endif /*  USE_MOUSE_HOVER */
-#endif /* USE_MOUSE_EVENTS */
 
 void WeaselPanel::_HighlightText(CDCHandle &dc, CRect rc, COLORREF color, COLORREF shadowColor, int radius, BackType type = BackType::TEXT, IsToRoundStruct rd = IsToRoundStruct(), COLORREF bordercolor=TRANS_COLOR)
 {
@@ -797,10 +794,8 @@ void WeaselPanel::DoPaint(CDCHandle dc)
 	}
 	_LayerUpdate(rcw, memDC);
 
-#ifdef USE_MOUSE_EVENTS
 	// turn off WS_EX_TRANSPARENT after drawings, for better resp performance
 	::SetWindowLong(m_hWnd, GWL_EXSTYLE, ::GetWindowLong(m_hWnd, GWL_EXSTYLE) & (~WS_EX_TRANSPARENT));
-#endif
 	// clean objs
 	::DeleteDC(memDC);
 	::DeleteObject(memBitmap);

--- a/WeaselUI/WeaselPanel.cpp
+++ b/WeaselUI/WeaselPanel.cpp
@@ -50,7 +50,7 @@ WeaselPanel::WeaselPanel(weasel::UI& ui)
 	dpi(96),
 	hide_candidates(false),
 	pDWR(ui.pdwr()),
-	_SelectCallback(ui.selectCallback()),
+	_UICallback(ui.uiCallback()),
 	_m_gdiplusToken(0)
 {
 	m_iconDisabled.LoadIconW(IDI_RELOAD, STATUS_ICON_SIZE, STATUS_ICON_SIZE, LR_DEFAULTCOLOR);
@@ -146,7 +146,7 @@ void WeaselPanel::Refresh()
 void WeaselPanel::_InitFontRes(void)
 {
 	HMONITOR hMonitor = MonitorFromRect(m_inputPos, MONITOR_DEFAULTTONEAREST);
-	UINT dpiX = 0, dpiY = 0;
+	UINT dpiX = 96, dpiY = 96;
 	if (hMonitor)
 		GetDpiForMonitor(hMonitor, MDT_EFFECTIVE_DPI, &dpiX, &dpiY);
 	// prepare d2d1 resources
@@ -212,22 +212,14 @@ LRESULT WeaselPanel::OnMouseActivate(UINT uMsg, WPARAM wParam, LPARAM lParam, BO
 	return MA_NOACTIVATE;
 }
 
-// simulating a key down and up
-static void SendInputKey(WORD key)
-{
-	INPUT inputs[2];
-	inputs[0].type = INPUT_KEYBOARD;
-	inputs[0].ki = {key, 0,0,0,0};
-	inputs[1].type = INPUT_KEYBOARD;
-	inputs[1].ki = {key, 0,KEYEVENTF_KEYUP,0,0};
-	::SendInput(sizeof(inputs) / sizeof(INPUT), inputs, sizeof(INPUT));
-}
-
 LRESULT WeaselPanel::OnMouseWheel(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
 	int delta = GET_WHEEL_DELTA_WPARAM(wParam);
-	if(delta > 0) SendInputKey(33);
-	else	   SendInputKey(34);
+	if(_UICallback && delta != 0)
+	{
+		bool nextpage = delta < 0;
+		_UICallback(NULL, NULL, &nextpage);
+	}
 	bHandled = true;
 	return 0;
 }
@@ -260,8 +252,9 @@ LRESULT WeaselPanel::OnLeftClicked(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL
 				CRect prc = m_layout->GetPrepageRect();
 				if(m_istorepos)	prc.OffsetRect(0, m_offsety_preedit);
 				if(prc.PtInRect(point)) {
-					// to do send pgup
-					SendInputKey(33);
+					bool nextPage = false;
+					if(_UICallback)
+						_UICallback(NULL, NULL, &nextPage);
 					bHandled = true;
 					return 0;
 				}
@@ -271,22 +264,23 @@ LRESULT WeaselPanel::OnLeftClicked(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL
 				CRect prc = m_layout->GetNextpageRect();
 				if(m_istorepos)	prc.OffsetRect(0, m_offsety_preedit);
 				if(prc.PtInRect(point)) {
-					// to do send pgdn
-					SendInputKey(34);
+					bool nextPage = true;
+					if(_UICallback)
+						_UICallback(NULL, NULL, &nextPage);
 					bHandled = true;
 					return 0;
 				}
 			}
 		}
 		// select by click
-		for (auto i = 0; i < m_candidateCount && i < MAX_CANDIDATES_COUNT; ++i) {
+		for (size_t i = 0; i < m_candidateCount && i < MAX_CANDIDATES_COUNT; ++i) {
 			CRect rect = m_layout->GetCandidateRect((int)i);
 			if(m_istorepos)	rect.OffsetRect(0, m_offsetys[i]);
 			rect.InflateRect(m_style.hilite_padding_x, m_style.hilite_padding_y);
 			if (rect.PtInRect(point))
 			{
-				if (_SelectCallback)
-					_SelectCallback(m_ctx.cinfo.candies.at(i).str, i);
+				if(_UICallback)
+					_UICallback(&i, NULL, NULL);
 				break;
 			}
 		}
@@ -304,10 +298,12 @@ LRESULT WeaselPanel::OnMouseHover(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL&
 
 	for (size_t i = 0; i < m_candidateCount && i < MAX_CANDIDATES_COUNT; ++i) {
 		CRect rect = m_layout->GetCandidateRect((int)i);
-		if (rect.PtInRect(point))
+		if (m_istorepos)
+			rect.OffsetRect(0, m_offsetys[i]);
+		if (rect.PtInRect(point) && i != m_ctx.cinfo.highlighted)
 		{
-			m_ctx.cinfo.highlighted = i;
-			Refresh();
+			if (_UICallback)
+				_UICallback(NULL, &i, NULL);
 		}
 	}
 	bHandled = true;
@@ -331,7 +327,6 @@ LRESULT WeaselPanel::OnMouseMove(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& 
 LRESULT WeaselPanel::OnMouseLeave(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
 	m_mouse_entry = false;
-	Refresh();
 	return 0;
 }
 #endif /*  USE_MOUSE_HOVER */

--- a/WeaselUI/WeaselPanel.cpp
+++ b/WeaselUI/WeaselPanel.cpp
@@ -50,6 +50,7 @@ WeaselPanel::WeaselPanel(weasel::UI& ui)
 	dpi(96),
 	hide_candidates(false),
 	pDWR(ui.pdwr()),
+	_SelectCallback(ui.selectCallback()),
 	_m_gdiplusToken(0)
 {
 	m_iconDisabled.LoadIconW(IDI_RELOAD, STATUS_ICON_SIZE, STATUS_ICON_SIZE, LR_DEFAULTCOLOR);
@@ -284,9 +285,8 @@ LRESULT WeaselPanel::OnLeftClicked(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL
 			rect.InflateRect(m_style.hilite_padding_x, m_style.hilite_padding_y);
 			if (rect.PtInRect(point))
 			{
-				// if not select by number, to be test
-				if(i < MAX_CANDIDATES_COUNT - 1) SendInputKey(0x31 + i);
-				else	SendInputKey(0x30);
+				if (_SelectCallback)
+					_SelectCallback(m_ctx.cinfo.candies.at(i).str, i);
 				break;
 			}
 		}

--- a/WeaselUI/WeaselPanel.h
+++ b/WeaselUI/WeaselPanel.h
@@ -61,6 +61,7 @@ public:
 	void MoveTo(RECT const& rc);
 	void Refresh();
 	void DoPaint(CDCHandle dc);
+	bool GetIsReposition(){ return m_istorepos; }
 
 private:
 	void _InitFontRes(void);

--- a/WeaselUI/WeaselPanel.h
+++ b/WeaselUI/WeaselPanel.h
@@ -119,5 +119,5 @@ private:
 	bool hide_candidates;
 	// for multi font_face & font_point
 	PDWR pDWR;
-	std::function<void(const std::wstring, const size_t index)>& _SelectCallback;
+	std::function<void(size_t *const, size_t *const, bool *const)>& _UICallback;
 };

--- a/WeaselUI/WeaselPanel.h
+++ b/WeaselUI/WeaselPanel.h
@@ -28,32 +28,24 @@ public:
 		MESSAGE_HANDLER(WM_CREATE, OnCreate)
 		MESSAGE_HANDLER(WM_DESTROY, OnDestroy)
 		MESSAGE_HANDLER(WM_DPICHANGED, OnDpiChanged)
-#ifdef USE_MOUSE_EVENTS
 		MESSAGE_HANDLER(WM_MOUSEACTIVATE, OnMouseActivate)
 		MESSAGE_HANDLER(WM_LBUTTONDOWN, OnLeftClicked)
 		MESSAGE_HANDLER(WM_MOUSEWHEEL, OnMouseWheel)
-#ifdef USE_MOUSE_HOVER
 		MESSAGE_HANDLER(WM_MOUSEHOVER, OnMouseHover)
 		MESSAGE_HANDLER(WM_MOUSEMOVE, OnMouseMove)
 		MESSAGE_HANDLER(WM_MOUSELEAVE, OnMouseLeave)
-#endif /*  USE_MOUSE_HOVER */
-#endif /* USE_MOUSE_EVENTS */
 		CHAIN_MSG_MAP(CDoubleBufferImpl<WeaselPanel>)
 	END_MSG_MAP()
 
 	LRESULT OnCreate(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
 	LRESULT OnDestroy(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
 	LRESULT OnDpiChanged(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
-#ifdef USE_MOUSE_EVENTS
 	LRESULT OnMouseActivate(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
 	LRESULT OnLeftClicked(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
 	LRESULT OnMouseWheel(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
-#ifdef USE_MOUSE_HOVER
 	LRESULT OnMouseHover(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
 	LRESULT OnMouseMove(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
 	LRESULT OnMouseLeave(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
-#endif /*  USE_MOUSE_HOVER */
-#endif	/* USE_MOUSE_EVENTS */
 
 	WeaselPanel(weasel::UI &ui);
 	~WeaselPanel();
@@ -65,12 +57,8 @@ public:
 
 private:
 	void _InitFontRes(void);
-#ifdef USE_MOUSE_EVENTS
 	void _CaptureRect(CRect& rect);
-#ifdef USE_MOUSE_HOVER
 	bool m_mouse_entry = false;
-#endif /*  USE_MOUSE_HOVER */
-#endif	/* USE_MOUSE_EVENTS */
 	void _CreateLayout();
 	void _ResizeWindow();
 	void _RepositionWindow(bool adj = false);

--- a/WeaselUI/WeaselPanel.h
+++ b/WeaselUI/WeaselPanel.h
@@ -118,4 +118,5 @@ private:
 	bool hide_candidates;
 	// for multi font_face & font_point
 	PDWR pDWR;
+	std::function<void(const std::wstring, const size_t index)>& _SelectCallback;
 };

--- a/WeaselUI/WeaselUI.cpp
+++ b/WeaselUI/WeaselUI.cpp
@@ -124,6 +124,14 @@ void UI::Destroy(bool full)
 	}
 }
 
+bool UI::GetIsReposition()
+{
+	if( pimpl_ ) 
+		return pimpl_->panel.GetIsReposition(); 
+	else
+		return false;
+}
+
 void UI::Show()
 {
 	if (pimpl_)

--- a/include/RimeWithWeasel.h
+++ b/include/RimeWithWeasel.h
@@ -22,6 +22,7 @@ public:
 	virtual BOOL ProcessKeyEvent(weasel::KeyEvent keyEvent, UINT session_id, EatLine eat);
 	virtual void CommitComposition(UINT session_id);
 	virtual void ClearComposition(UINT session_id);
+	virtual void SelectCandidateOnCurrentPage(size_t index, UINT session_id);
 	virtual void FocusIn(DWORD param, UINT session_id);
 	virtual void FocusOut(DWORD param, UINT session_id);
 	virtual void UpdateInputPosition(RECT const& rc, UINT session_id);

--- a/include/WeaselCommon.h
+++ b/include/WeaselCommon.h
@@ -9,8 +9,6 @@
 #define WEASEL_REG_KEY L"Software\\Rime\\Weasel"
 #define RIME_REG_KEY L"Software\\Rime"
 
-#define USE_MOUSE_EVENTS
-#define USE_MOUSE_HOVER
 //#define USE_SHARP_COLOR_CODE
 
 //#define _DEBUG_
@@ -285,6 +283,7 @@ namespace weasel
 		std::wstring font_face;
 		std::wstring label_font_face;
 		std::wstring comment_font_face;
+		int mouse_hover_ms;
 		int font_point;
 		int label_font_point;
 		int comment_font_point;
@@ -347,6 +346,7 @@ namespace weasel
 		UIStyle() : font_face(),
 			label_font_face(),
 			comment_font_face(),
+			mouse_hover_ms(0),
 			font_point(0),
 			label_font_point(0),
 			comment_font_point(0),
@@ -421,6 +421,7 @@ namespace weasel
 					|| font_face != st.font_face
 					|| label_font_face != st.label_font_face
 					|| comment_font_face != st.comment_font_face
+					|| mouse_hover_ms != st.mouse_hover_ms
 					|| font_point != st.font_point
 					|| label_font_point != st.label_font_point
 					|| comment_font_point != st.comment_font_point
@@ -486,6 +487,7 @@ namespace boost {
 			ar & s.font_face;
 			ar & s.label_font_face;
 			ar & s.comment_font_face;
+			ar & s.mouse_hover_ms;
 			ar & s.font_point;
 			ar & s.label_font_point;
 			ar & s.comment_font_point;

--- a/include/WeaselCommon.h
+++ b/include/WeaselCommon.h
@@ -280,6 +280,7 @@ namespace weasel
 		LayoutType layout_type;
 		bool vertical_text_left_to_right;
 		bool vertical_text_with_wrap;
+		bool paging_on_scroll;
 		std::wstring font_face;
 		std::wstring label_font_face;
 		std::wstring comment_font_face;
@@ -367,6 +368,7 @@ namespace weasel
 			layout_type(LAYOUT_VERTICAL),
 			vertical_text_left_to_right(false),
 			vertical_text_with_wrap(false),
+			paging_on_scroll(false),
 			min_width(0),
 			max_width(0),
 			min_height(0),
@@ -418,6 +420,7 @@ namespace weasel
 					|| layout_type != st.layout_type
 					|| vertical_text_left_to_right != st.vertical_text_left_to_right
 					|| vertical_text_with_wrap != st.vertical_text_with_wrap
+					|| paging_on_scroll != st.paging_on_scroll
 					|| font_face != st.font_face
 					|| label_font_face != st.label_font_face
 					|| comment_font_face != st.comment_font_face
@@ -508,6 +511,7 @@ namespace boost {
 			ar & s.layout_type;
 			ar & s.vertical_text_left_to_right;
 			ar & s.vertical_text_with_wrap;
+			ar & s.paging_on_scroll;
 			ar & s.min_width;
 			ar & s.max_width;
 			ar & s.min_height;

--- a/include/WeaselCommon.h
+++ b/include/WeaselCommon.h
@@ -10,7 +10,7 @@
 #define RIME_REG_KEY L"Software\\Rime"
 
 #define USE_MOUSE_EVENTS
-//#define USE_MOUSE_HOVER
+#define USE_MOUSE_HOVER
 //#define USE_SHARP_COLOR_CODE
 
 //#define _DEBUG_

--- a/include/WeaselIPC.h
+++ b/include/WeaselIPC.h
@@ -27,6 +27,7 @@ enum WEASEL_IPC_COMMAND
 	WEASEL_IPC_END_MAINTENANCE,
 	WEASEL_IPC_COMMIT_COMPOSITION,
 	WEASEL_IPC_CLEAR_COMPOSITION,
+	WEASEL_IPC_SELECT_CANDIDATE_ON_CURRENT_PAGE,
 	WEASEL_IPC_TRAY_COMMAND,
 	WEASEL_IPC_LAST_COMMAND
 };
@@ -76,6 +77,7 @@ namespace weasel
 		virtual BOOL ProcessKeyEvent(KeyEvent keyEvent, UINT session_id, EatLine eat) { return FALSE; }
 		virtual void CommitComposition(UINT session_id) {}
 		virtual void ClearComposition(UINT session_id) {}
+		virtual void SelectCandidateOnCurrentPage(size_t index, UINT session_id) {}
 		virtual void FocusIn(DWORD param, UINT session_id) {}
 		virtual void FocusOut(DWORD param, UINT session_id) {}
 		virtual void UpdateInputPosition(RECT const& rc, UINT session_id) {}
@@ -130,6 +132,8 @@ namespace weasel
 		bool CommitComposition();
 		// 清除正在編輯的文字
 		bool ClearComposition();
+		// 选择当前页面编号为index的候选
+		bool SelectCandidateOnCurrentPage(size_t index);
 		// 更新输入位置
 		void UpdateInputPosition(RECT const& rc);
 		// 输入窗口获得焦点

--- a/include/WeaselUI.h
+++ b/include/WeaselUI.h
@@ -80,6 +80,7 @@ namespace weasel
 		UIStyle& style() { return style_; }
 		UIStyle& ostyle() { return ostyle_; }
 		PDWR pdwr() { return pDWR; }
+		bool GetIsReposition(); 
 		std::function<void(const std::wstring, const size_t index)>& selectCallback() { return _SelectCallback; }
 		void SetSelectCallback(std::function<void(const std::wstring, const size_t index)> const & func) { _SelectCallback = func; }
 

--- a/include/WeaselUI.h
+++ b/include/WeaselUI.h
@@ -81,8 +81,9 @@ namespace weasel
 		UIStyle& ostyle() { return ostyle_; }
 		PDWR pdwr() { return pDWR; }
 		bool GetIsReposition(); 
-		std::function<void(const std::wstring, const size_t index)>& selectCallback() { return _SelectCallback; }
-		void SetSelectCallback(std::function<void(const std::wstring, const size_t index)> const & func) { _SelectCallback = func; }
+
+		std::function<void(size_t* const, size_t* const, bool* const)>& uiCallback() { return _UICallback; }
+		void SetUICallBack(std::function<void(size_t* const, size_t* const, bool* const)> const & func) { _UICallback = func; }
 
 	private:
 		UIImpl* pimpl_;
@@ -93,7 +94,7 @@ namespace weasel
 		Status status_;
 		UIStyle style_;
 		UIStyle ostyle_;
-		std::function<void(const std::wstring, const size_t index)> _SelectCallback;
+		std::function<void(size_t* const, size_t* const, bool* const)> _UICallback;
 	};
 
 	class DirectWriteResources

--- a/include/WeaselUI.h
+++ b/include/WeaselUI.h
@@ -8,6 +8,7 @@
 #include <dwrite_2.h>
 #include <memory>
 #include <wrl/client.h>
+#include <functional>
 using namespace Microsoft::WRL;
 namespace weasel
 {
@@ -79,6 +80,8 @@ namespace weasel
 		UIStyle& style() { return style_; }
 		UIStyle& ostyle() { return ostyle_; }
 		PDWR pdwr() { return pDWR; }
+		std::function<void(const std::wstring, const size_t index)>& selectCallback() { return _SelectCallback; }
+		void SetSelectCallback(std::function<void(const std::wstring, const size_t index)> const & func) { _SelectCallback = func; }
 
 	private:
 		UIImpl* pimpl_;
@@ -89,6 +92,7 @@ namespace weasel
 		Status status_;
 		UIStyle style_;
 		UIStyle ostyle_;
+		std::function<void(const std::wstring, const size_t index)> _SelectCallback;
 	};
 
 	class DirectWriteResources

--- a/output/data/weasel.yaml
+++ b/output/data/weasel.yaml
@@ -27,6 +27,7 @@ style:
   label_format: "%s."
   mark_text: ""
   mouse_hover_ms: 0
+  paging_on_scroll: false
   vertical_auto_reverse: false
   vertical_text: false
   vertical_text_left_to_right: false

--- a/output/data/weasel.yaml
+++ b/output/data/weasel.yaml
@@ -26,6 +26,7 @@ style:
   display_tray_icon: false
   label_format: "%s."
   mark_text: ""
+  mouse_hover_ms: 0
   vertical_auto_reverse: false
   vertical_text: false
   vertical_text_left_to_right: false


### PR DESCRIPTION
1. 鼠标点击选词、滚轮翻页（点击翻页）以及鼠标悬停响应功能重构，修复 fixed #867 
2. 新特性: 参数 `style/mouse_hover_ms: integer ` 控制鼠标悬停响应间隔，设置为0 时禁用该功能（默认）
3. 新特性: 参数 `style/paging_on_scroll: bool`, 设定在候选窗口上滚轮操作时，对应的响应动作。如设定为true，则进行翻页操作；如设定为false （默认)，则进行候选index切换（类似上下方向键）
4. 杂项：当vertical布局倒序排列时，使方向键和绘图光标的变化同步 [原文](https://github.com/rime/home/discussions/1214#discussioncomment-6142583)

![excel](https://github.com/rime/weasel/assets/4023160/3bd0b708-1d89-460d-9188-410a635fd225)

![hover](https://github.com/rime/weasel/assets/4023160/e0afe6c8-72a3-41e3-a315-d91d3cdbb19a)
