### PR TITLE
fixed: hilited mark covered by hilited_candidate_back_color, when mark_text empty and hilited_mark_color not transparent

### DIFF
--- a/WeaselUI/WeaselPanel.cpp
+++ b/WeaselUI/WeaselPanel.cpp
@@ -635,6 +635,7 @@ bool WeaselPanel::_DrawCandidates(CDCHandle &dc, bool back)
 				ReconfigRoundInfo(rd, m_ctx.cinfo.highlighted, m_candidateCount);
 			}
 			rect.InflateRect(m_style.hilite_padding_x, m_style.hilite_padding_y);
+			_HighlightText(dc, rect, m_style.hilited_candidate_back_color, m_style.hilited_candidate_shadow_color, m_style.round_corner, bkType, rd, m_style.hilited_candidate_border_color);
 			if (m_style.mark_text.empty() && COLORNOTTRANSPARENT(m_style.hilited_mark_color))
 			{
 				BYTE r = GetRValue(m_style.hilited_mark_color);
@@ -658,7 +659,6 @@ bool WeaselPanel::_DrawCandidates(CDCHandle &dc, bool back)
 					g_back.FillPath(&mk_brush, &mk_path);
 				}
 			}
-			_HighlightText(dc, rect, m_style.hilited_candidate_back_color, m_style.hilited_candidate_shadow_color, m_style.round_corner, bkType, rd, m_style.hilited_candidate_border_color);
 			drawn = true;
 		}
 	}


### PR DESCRIPTION
如题，修复新增的高亮标识状态(hilited_mark_color非透明 && mark_text为空）被hilited_candidate_back_color遮盖的问题
测试确认图如下
![image](https://github.com/rime/weasel/assets/4023160/a882083d-fece-4087-8a41-24759d093d47)
