### PR TITLE
increase PipeChannel bs default value up to 64kB

### DIFF
--- a/include/PipeChannel.h
+++ b/include/PipeChannel.h
@@ -70,7 +70,7 @@ namespace weasel {
 		};
 
 	public:
-		PipeChannel(std::wstring &&pn_cmd, SECURITY_ATTRIBUTES *s = NULL, size_t bs = 4 * 1024)
+		PipeChannel(std::wstring &&pn_cmd, SECURITY_ATTRIBUTES *s = NULL, size_t bs = 64 * 1024)
 			: PipeChannelBase(std::move(pn_cmd), bs, s)
 		{}
 


### PR DESCRIPTION
enable longer content transaction, longer candidates' info