### PR TITLE
feat: add option shown_notifications_when: {string}, to determine when to show notifications

### DIFF
--- a/include/RimeWithWeasel.h
+++ b/include/RimeWithWeasel.h
@@ -55,6 +55,7 @@ private:
 	std::string m_last_schema_id;
 	std::string m_last_app_name;
 	weasel::UIStyle m_base_style;
+	UINT m_show_notifications_when;
 
 	std::function<void()> _UpdateUICallback;
 

--- a/output/data/weasel.yaml
+++ b/output/data/weasel.yaml
@@ -9,6 +9,11 @@ app_options:
   conhost.exe:
     ascii_mode: true
 
+# configuration: when to show notifications
+# always, never, or combination of: ascii_mode, ascii_punct, shape, simplification, schema
+# e.g., ascii_mode+shape+schema
+show_notifications_when: always
+
 style:
   antialias_mode: default
   ascii_tip_follow_cursor: false


### PR DESCRIPTION
by this pr,  we can determine when to show notifications, except deployment's.

for example, set `show_notifications_when: never` could disable all notifications except msg from deployment.

```yaml
#in weasel.yaml

# configuration: when to show notifications
# always, never, or combination of: ascii_mode, ascii_punct, shape, simplification, schema
# e.g., ascii_mode+shape+schema
show_notifications_when: always

```