### PR TITLE
UI performance, some fix and features

### DIFF
--- a/RimeWithWeasel/RimeWithWeasel.cpp
+++ b/RimeWithWeasel/RimeWithWeasel.cpp
@@ -839,13 +839,13 @@ static void _RimeGetBool(RimeConfig* config, char* key, bool cond, T& value, con
 }
 //	parse string option to T type value, with fallback 
 template <typename T>
-void _RimeParseStringOpt(RimeConfig* config, const std::string key, T& value, const std::map<std::string, T> amap) {
+void _RimeParseStringOptWithFallback(RimeConfig* config, const std::string key, T& value, const std::map<std::string, T> amap, const T& fallback) {
 	char str_buff[256] = { 0 };
 	if (RimeConfigGetString(config, key.c_str(), str_buff, sizeof(str_buff) - 1)) {
 		auto it = amap.find(std::string(str_buff));
-		if(it != amap.end())
-			value =  it->second;
+		value = (it != amap.end()) ? it->second : fallback;
 	} 
+	else value = fallback;
 }
 static inline void _abs(int* value) { *value = abs(*value); }	// turn *value to be non-negative
 // get int type value with fallback key fb_key, and func to execute after reading
@@ -928,7 +928,7 @@ static void _UpdateUIStyle(RimeConfig* config, UI* ui, bool initialize)
 		{std::string("preview"),		UIStyle::PREVIEW}, 
 		{std::string("preview_all"),	UIStyle::PREVIEW_ALL} 
 	};
-	_RimeParseStringOpt(config, "style/preedit_type", style.preedit_type, _preeditMap);
+	_RimeParseStringOptWithFallback(config, "style/preedit_type", style.preedit_type, _preeditMap, style.preedit_type);
 	const std::map < std::string , UIStyle::AntiAliasMode > _aliasModeMap = {
 		{std::string("force_dword"),	UIStyle::FORCE_DWORD},
 		{std::string("cleartype"),		UIStyle::CLEARTYPE},
@@ -936,13 +936,13 @@ static void _UpdateUIStyle(RimeConfig* config, UI* ui, bool initialize)
 		{std::string("aliased"),		UIStyle::ALIASED},
 		{std::string("default"),		UIStyle::DEFAULT}
 	};
-	_RimeParseStringOpt(config, "style/antialias_mode", style.antialias_mode, _aliasModeMap);
+	_RimeParseStringOptWithFallback(config, "style/antialias_mode", style.antialias_mode, _aliasModeMap, style.antialias_mode);
 	const std::map<std::string, UIStyle::LayoutAlignType> _alignType = {
 		{std::string("top"),	UIStyle::ALIGN_TOP},
 		{std::string("center"),	UIStyle::ALIGN_CENTER},
 		{std::string("bottom"),	UIStyle::ALIGN_BOTTOM}
 	};
-	_RimeParseStringOpt(config, "style/layout/align_type", style.align_type, _alignType);
+	_RimeParseStringOptWithFallback(config, "style/layout/align_type", style.align_type, _alignType, style.align_type);
 	_RimeGetBool(config, "style/display_tray_icon", initialize, style.display_tray_icon, true, false);
 	_RimeGetBool(config, "style/ascii_tip_follow_cursor", initialize, style.ascii_tip_follow_cursor, true, false);
 	_RimeGetBool(config, "style/horizontal", initialize, style.layout_type, UIStyle::LAYOUT_HORIZONTAL, UIStyle::LAYOUT_VERTICAL);
@@ -957,7 +957,7 @@ static void _UpdateUIStyle(RimeConfig* config, UI* ui, bool initialize)
 		{std::string("vertical"), true}
 	};
 	bool _text_orientation_bool = false;
-	_RimeParseStringOpt(config, "style/text_orientation", _text_orientation_bool, _text_orientation);
+	_RimeParseStringOptWithFallback(config, "style/text_orientation", _text_orientation_bool, _text_orientation, _text_orientation_bool);
 	if(_text_orientation_bool)
 		style.layout_type = UIStyle::LAYOUT_VERTICAL_TEXT;
 	_RimeGetStringWithFunc(config, "style/label_format", style.label_text_format);
@@ -974,7 +974,7 @@ static void _UpdateUIStyle(RimeConfig* config, UI* ui, bool initialize)
 		{std::string("vertical+fullscreen"),		UIStyle::LAYOUT_VERTICAL_FULLSCREEN},
 		{std::string("horizontal+fullscreen"),		UIStyle::LAYOUT_HORIZONTAL_FULLSCREEN}
 	};
-	_RimeParseStringOpt(config, "style/layout/type", style.layout_type, _layoutMap);
+	_RimeParseStringOptWithFallback(config, "style/layout/type", style.layout_type, _layoutMap, style.layout_type);
 	// disable max_width when full screen
 	if( style.layout_type == UIStyle::LAYOUT_HORIZONTAL_FULLSCREEN || style.layout_type == UIStyle::LAYOUT_VERTICAL_FULLSCREEN )
 	{
@@ -1056,7 +1056,7 @@ static bool _UpdateUIStyleColor(RimeConfig* config, UIStyle& style, std::string 
 			{std::string("rgba"), COLOR_RGBA},
 			{std::string("abgr"), COLOR_ABGR}
 		};
-		_RimeParseStringOpt(config, (prefix+"/color_format"), fmt, _colorFmt);
+		_RimeParseStringOptWithFallback(config, (prefix+"/color_format"), fmt, _colorFmt, COLOR_ABGR);
 		_RimeConfigGetColor32bWithFallback(config, (prefix + "/back_color"), style.back_color, fmt, 0xffffffff);
 		_RimeConfigGetColor32bWithFallback(config, (prefix + "/shadow_color"), style.shadow_color, fmt, TRANSPARENT_COLOR);
 		_RimeConfigGetColor32bWithFallback(config, (prefix + "/prevpage_color"), style.prevpage_color, fmt, TRANSPARENT_COLOR);

--- a/RimeWithWeasel/RimeWithWeasel.cpp
+++ b/RimeWithWeasel/RimeWithWeasel.cpp
@@ -921,6 +921,7 @@ static void _UpdateUIStyle(RimeConfig* config, UI* ui, bool initialize)
 	_RimeGetIntWithFallback(config, "style/label_font_point", &style.label_font_point, "style/font_point", _abs);
 	_RimeGetIntWithFallback(config, "style/comment_font_point", &style.comment_font_point, "style/font_point", _abs);
 	_RimeGetIntWithFallback(config, "style/mouse_hover_ms", &style.mouse_hover_ms, NULL, _abs);
+	_RimeGetIntWithFallback(config, "style/candidate_abbreviate_length", &style.candidate_abbreviate_length, NULL, _abs);
 	_RimeGetBool(config, "style/inline_preedit", initialize, style.inline_preedit, true, false);
 	_RimeGetBool(config, "style/vertical_auto_reverse", initialize, style.vertical_auto_reverse, true, false);
 	const std::map<std::string, UIStyle::PreeditType> _preeditMap = { 

--- a/RimeWithWeasel/RimeWithWeasel.cpp
+++ b/RimeWithWeasel/RimeWithWeasel.cpp
@@ -948,6 +948,7 @@ static void _UpdateUIStyle(RimeConfig* config, UI* ui, bool initialize)
 	_RimeGetBool(config, "style/ascii_tip_follow_cursor", initialize, style.ascii_tip_follow_cursor, true, false);
 	_RimeGetBool(config, "style/horizontal", initialize, style.layout_type, UIStyle::LAYOUT_HORIZONTAL, UIStyle::LAYOUT_VERTICAL);
 	_RimeGetBool(config, "style/paging_on_scroll", initialize, style.paging_on_scroll, true, false);
+	_RimeGetBool(config, "style/click_to_capture", initialize, style.click_to_capture, true, false);
 	_RimeGetBool(config, "style/fullscreen", false, style.layout_type, 
 			((style.layout_type == UIStyle::LAYOUT_HORIZONTAL) ? UIStyle::LAYOUT_HORIZONTAL_FULLSCREEN : UIStyle::LAYOUT_VERTICAL_FULLSCREEN), style.layout_type);
 	_RimeGetBool(config, "style/vertical_text", false, style.layout_type, UIStyle::LAYOUT_VERTICAL_TEXT, style.layout_type);

--- a/WeaselUI/DirectWriteResources.cpp
+++ b/WeaselUI/DirectWriteResources.cpp
@@ -87,9 +87,9 @@ DirectWriteResources::~DirectWriteResources()
 	pD2d1Factory.Reset();
 }
 
-HRESULT DirectWriteResources::InitResources(std::wstring label_font_face, int label_font_point,
-	std::wstring font_face, int font_point,
-	std::wstring comment_font_face, int comment_font_point, bool vertical_text) 
+HRESULT DirectWriteResources::InitResources(const std::wstring& label_font_face, const int& label_font_point,
+	const std::wstring& font_face, const int& font_point,
+	const std::wstring& comment_font_face, const int& comment_font_point, const bool& vertical_text) 
 {
 	// prepare d2d1 resources
 	pPreeditTextFormat.Reset();
@@ -131,14 +131,13 @@ HRESULT DirectWriteResources::InitResources(std::wstring label_font_face, int la
 		pTextFormat->SetWordWrapping(wrapping);
 		_SetFontFallback(pTextFormat, fontFaceStrVector);
 	}
-	fontFaceStrVector.swap(std::vector<std::wstring>());
+	decltype(fontFaceStrVector)().swap(fontFaceStrVector);
 
 	fontFaceStrVector = ws_split(font_face, L",");
 	//_ParseFontFace(fontFaceStrVector[0], fontWeight, fontStyle);
 	fontFaceStrVector[0] = std::regex_replace(fontFaceStrVector[0], std::wregex(STYLEORWEIGHT, std::wregex::icase), L"");
 	hResult = pDWFactory->CreateTextFormat(_mainFontFace.c_str(), NULL,
 			fontWeight, fontStyle, DWRITE_FONT_STRETCH_NORMAL,
-			//font_point * dpiScaleX_, L"", reinterpret_cast<IDWriteTextFormat**>(&pPreeditTextFormat));
 			font_point * dpiScaleX_, L"", reinterpret_cast<IDWriteTextFormat**>(pPreeditTextFormat.GetAddressOf()));
 	if( pPreeditTextFormat != NULL)
 	{
@@ -154,7 +153,7 @@ HRESULT DirectWriteResources::InitResources(std::wstring label_font_face, int la
 		pPreeditTextFormat->SetWordWrapping(wrapping);
 		_SetFontFallback(pPreeditTextFormat, fontFaceStrVector);
 	}
-	fontFaceStrVector.swap(std::vector<std::wstring>());
+	decltype(fontFaceStrVector)().swap(fontFaceStrVector);
 
 	// label font text format set up
 	fontFaceStrVector = ws_split(label_font_face, L",");
@@ -178,7 +177,7 @@ HRESULT DirectWriteResources::InitResources(std::wstring label_font_face, int la
 		pLabelTextFormat->SetWordWrapping(wrapping);
 		_SetFontFallback(pLabelTextFormat, fontFaceStrVector);
 	}
-	fontFaceStrVector.swap(std::vector<std::wstring>());
+	decltype(fontFaceStrVector)().swap(fontFaceStrVector);
 
 	// comment font text format set up
 	fontFaceStrVector = ws_split(comment_font_face, L",");
@@ -202,11 +201,11 @@ HRESULT DirectWriteResources::InitResources(std::wstring label_font_face, int la
 		pCommentTextFormat->SetWordWrapping(wrapping);
 		_SetFontFallback(pCommentTextFormat, fontFaceStrVector);
 	}
-	fontFaceStrVector.swap(std::vector<std::wstring>());
+	decltype(fontFaceStrVector)().swap(fontFaceStrVector);
 	return hResult;
 }
 
-HRESULT DirectWriteResources::InitResources(UIStyle& style, UINT dpi = 96)
+HRESULT DirectWriteResources::InitResources(const UIStyle& style, const UINT& dpi = 96)
 {
 	_style = style;
 	if(dpi)
@@ -218,7 +217,7 @@ HRESULT DirectWriteResources::InitResources(UIStyle& style, UINT dpi = 96)
 		style.comment_font_face, style.comment_font_point, style.layout_type==UIStyle::LAYOUT_VERTICAL_TEXT);
 }
 
-void weasel::DirectWriteResources::SetDpi(UINT dpi)
+void weasel::DirectWriteResources::SetDpi(const UINT& dpi)
 {
 	dpiScaleX_ = dpi / 72.0f;
 	dpiScaleY_ = dpi / 72.0f;
@@ -250,7 +249,7 @@ static std::wstring _MatchWordsOutLowerCaseTrim1st(const std::wstring& wstr, con
 	return res;
 }
 
-void DirectWriteResources::_ParseFontFace(const std::wstring fontFaceStr, DWRITE_FONT_WEIGHT& fontWeight, DWRITE_FONT_STYLE& fontStyle)
+void DirectWriteResources::_ParseFontFace(const std::wstring& fontFaceStr, DWRITE_FONT_WEIGHT& fontWeight, DWRITE_FONT_STYLE& fontStyle)
 {
 	const std::wstring patWeight(L"(:thin|:extra_light|:ultra_light|:light|:semi_light|:medium|:demi_bold|:semi_bold|:bold|:extra_bold|:ultra_bold|:black|:heavy|:extra_black|:ultra_black)");
 	const std::map<std::wstring, DWRITE_FONT_WEIGHT> _mapWeight = {
@@ -286,7 +285,7 @@ void DirectWriteResources::_ParseFontFace(const std::wstring fontFaceStr, DWRITE
 	fontStyle = (it2 != _mapStyle.end()) ? it2->second : DWRITE_FONT_STYLE_NORMAL;
 }
 
-void DirectWriteResources::_SetFontFallback(ComPtr<IDWriteTextFormat1> textFormat, std::vector<std::wstring> fontVector)
+void DirectWriteResources::_SetFontFallback(ComPtr<IDWriteTextFormat1> textFormat, const std::vector<std::wstring>& fontVector)
 {
 	ComPtr<IDWriteFontFallback> pSysFallback;
 	pDWFactory->GetSystemFontFallback(pSysFallback.GetAddressOf());
@@ -338,13 +337,13 @@ void DirectWriteResources::_SetFontFallback(ComPtr<IDWriteTextFormat1> textForma
 		DWRITE_UNICODE_RANGE range = { first, last };
 		const  WCHAR* familys = { _fontFaceWstr.c_str() };
 		pFontFallbackBuilder->AddMapping(&range, 1, &familys, 1);
-		fallbackFontsVector.swap(std::vector<std::wstring>());
+		decltype(fallbackFontsVector)().swap(fallbackFontsVector);
 	}
 	// add system defalt font fallback
 	pFontFallbackBuilder->AddMappings(pSysFallback.Get());
 	pFontFallbackBuilder->CreateFontFallback(pFontFallback.GetAddressOf());
 	textFormat->SetFontFallback(pFontFallback.Get());
-	fallbackFontsVector.swap(std::vector<std::wstring>());
+	decltype(fallbackFontsVector)().swap(fallbackFontsVector);
 	pFontFallback.Reset();
 	pSysFallback.Reset();
 	pFontFallbackBuilder.Reset();

--- a/WeaselUI/FullScreenLayout.cpp
+++ b/WeaselUI/FullScreenLayout.cpp
@@ -31,7 +31,10 @@ void weasel::FullScreenLayout::DoLayout(CDCHandle dc, PDWR pDWR)
 		if (!_style.mark_text.empty() && (_style.hilited_mark_color & 0xff000000))
 		{
 			CSize sg;
-			GetTextSizeDW(_style.mark_text, _style.mark_text.length(), pDWR->pTextFormat, pDWR, &sg);
+			if(_style.mark_text.empty())
+				GetTextSizeDW(L"|", 1, pDWR->pTextFormat, pDWR, &sg);
+			else
+				GetTextSizeDW(_style.mark_text, _style.mark_text.length(), pDWR->pTextFormat, pDWR, &sg);
 			MARK_WIDTH = sg.cx;
 			MARK_HEIGHT = sg.cy;
 			MARK_GAP = MARK_WIDTH + 4;

--- a/WeaselUI/HorizontalLayout.cpp
+++ b/WeaselUI/HorizontalLayout.cpp
@@ -22,7 +22,7 @@ void HorizontalLayout::DoLayout(CDCHandle dc, PDWR pDWR )
 		MARK_HEIGHT = sg.cy;
 		MARK_GAP = MARK_WIDTH + 4;
 	}
-	int base_offset =  ((_style.hilited_mark_color & 0xff000000) && !_style.mark_text.empty()) ? MARK_GAP : 0;
+	int base_offset =  ((_style.hilited_mark_color & 0xff000000)) ? MARK_GAP : 0;
 
 	// calc page indicator 
 	CSize pgszl, pgszr;

--- a/WeaselUI/Layout.h
+++ b/WeaselUI/Layout.h
@@ -68,6 +68,10 @@ namespace weasel
 		virtual CRect GetContentRect() = 0;
 		virtual CRect GetPrepageRect() = 0;
 		virtual CRect GetNextpageRect() = 0;
+		virtual weasel::TextRange GetPreeditRange() = 0; 
+		virtual CSize GetBeforeSize() = 0;
+		virtual CSize GetHilitedSize() = 0;
+		virtual CSize GetAfterSize() = 0;
 
 		virtual std::wstring GetLabelText(const std::vector<Text> &labels, int id, const wchar_t *format) const = 0;
 		virtual bool IsInlinePreedit() const = 0;

--- a/WeaselUI/StandardLayout.cpp
+++ b/WeaselUI/StandardLayout.cpp
@@ -78,7 +78,7 @@ void weasel::StandardLayout::GetTextSizeDW(const std::wstring text, size_t nCoun
 	pDWR->ResetLayout();
 }
 
-CSize StandardLayout::GetPreeditSize(CDCHandle dc, const weasel::Text& text, ComPtr<IDWriteTextFormat1> pTextFormat, PDWR pDWR) const
+CSize StandardLayout::GetPreeditSize(CDCHandle dc, const weasel::Text& text, ComPtr<IDWriteTextFormat1> pTextFormat, PDWR pDWR)
 {
 	const std::wstring& preedit = text.str;
 	const std::vector<weasel::TextAttribute> &attrs = text.attributes;
@@ -88,34 +88,33 @@ CSize StandardLayout::GetPreeditSize(CDCHandle dc, const weasel::Text& text, Com
 		weasel::TextRange range;
 		for (size_t j = 0; j < attrs.size(); ++j)
 			if (attrs[j].type == weasel::HIGHLIGHTED)
-				range = attrs[j].range;
-		if(range.start < range.end)
+				_range = attrs[j].range;
+		if(_range.start < _range.end)
 		{
-			std::wstring before_str = preedit.substr(0, range.start);
-			std::wstring hilited_str = preedit.substr(range.start, range.end);
-			std::wstring after_str = preedit.substr(range.end);
-			CSize beforesz(0,0), hilitedsz(0,0), aftersz(0,0);
-			GetTextSizeDW(before_str, before_str.length(), pTextFormat, pDWR, &beforesz);
-			GetTextSizeDW(hilited_str, hilited_str.length(), pTextFormat, pDWR, &hilitedsz);
-			GetTextSizeDW(after_str, after_str.length(), pTextFormat, pDWR, &aftersz);
+			std::wstring before_str = preedit.substr(0, _range.start);
+			std::wstring hilited_str = preedit.substr(_range.start, _range.end);
+			std::wstring after_str = preedit.substr(_range.end);
+			GetTextSizeDW(before_str, before_str.length(), pTextFormat, pDWR, &_beforesz);
+			GetTextSizeDW(hilited_str, hilited_str.length(), pTextFormat, pDWR, &_hilitedsz);
+			GetTextSizeDW(after_str, after_str.length(), pTextFormat, pDWR, &_aftersz);
 			auto width_max = 0, height_max = 0;
 			if(_style.layout_type == UIStyle::LAYOUT_VERTICAL_TEXT)
 			{
-				width_max = max(width_max, beforesz.cx);
-				width_max = max(width_max, hilitedsz.cx);
-				width_max = max(width_max, aftersz.cx);
-				height_max += beforesz.cy + (beforesz.cy > 0) * _style.hilite_spacing;
-				height_max += hilitedsz.cy + (hilitedsz.cy > 0) * _style.hilite_spacing;
-				height_max += aftersz.cy; // + (aftersz.cy > 0) * _style.hilite_spacing;
+				width_max = max(width_max, _beforesz.cx);
+				width_max = max(width_max, _hilitedsz.cx);
+				width_max = max(width_max, _aftersz.cx);
+				height_max += _beforesz.cy + (_beforesz.cy > 0) * _style.hilite_spacing;
+				height_max += _hilitedsz.cy + (_hilitedsz.cy > 0) * _style.hilite_spacing;
+				height_max += _aftersz.cy; 
 			}
 			else
 			{
-				height_max = max(height_max, beforesz.cy);
-				height_max = max(height_max, hilitedsz.cy);
-				height_max = max(height_max, aftersz.cy);
-				width_max += beforesz.cx + (beforesz.cx > 0) * _style.hilite_spacing;
-				width_max += hilitedsz.cx + (hilitedsz.cx > 0) * _style.hilite_spacing;
-				width_max += aftersz.cx ;// + (aftersz.cx > 0) * _style.hilite_spacing;
+				height_max = max(height_max, _beforesz.cy);
+				height_max = max(height_max, _hilitedsz.cy);
+				height_max = max(height_max, _aftersz.cy);
+				width_max += _beforesz.cx + (_beforesz.cx > 0) * _style.hilite_spacing;
+				width_max += _hilitedsz.cx + (_hilitedsz.cx > 0) * _style.hilite_spacing;
+				width_max += _aftersz.cx ;
 			}
 			size.cx = width_max;
 			size.cy = height_max;

--- a/WeaselUI/StandardLayout.h
+++ b/WeaselUI/StandardLayout.h
@@ -36,17 +36,23 @@ namespace weasel
 		virtual CRect GetContentRect() { return _contentRect; }
 		virtual CRect GetPrepageRect() { return _prePageRect; }
 		virtual CRect GetNextpageRect() { return _nextPageRect; }
+		virtual CSize GetBeforeSize() { return _beforesz; }
+		virtual CSize GetHilitedSize() { return _hilitedsz; }
+		virtual CSize GetAfterSize() { return _aftersz; }
+		virtual weasel::TextRange GetPreeditRange() { return _range; }
 
 		void GetTextSizeDW(const std::wstring text, size_t nCount, ComPtr<IDWriteTextFormat1> pTextFormat, PDWR pDWR, LPSIZE lpSize) const;
 
 	protected:
 		/* Utility functions */
-		CSize GetPreeditSize(CDCHandle dc, const weasel::Text& text, ComPtr<IDWriteTextFormat1> pTextFormat = NULL, PDWR pDWR = NULL) const;
+		CSize GetPreeditSize(CDCHandle dc, const weasel::Text& text, ComPtr<IDWriteTextFormat1> pTextFormat = NULL, PDWR pDWR = NULL);
 		bool _IsHighlightOverCandidateWindow(CRect& rc, CDCHandle& dc);
 		void _PrepareRoundInfo(CDCHandle& dc);
 
 		void UpdateStatusIconLayout(int* width, int* height);
 
+		CSize _beforesz, _hilitedsz, _aftersz;
+		weasel::TextRange _range;
 		CSize _contentSize;
 		CRect _preeditRect, _auxiliaryRect, _highlightRect;
 		CRect _candidateRects[MAX_CANDIDATES_COUNT];

--- a/WeaselUI/VHorizontalLayout.cpp
+++ b/WeaselUI/VHorizontalLayout.cpp
@@ -28,7 +28,7 @@ void VHorizontalLayout::DoLayout(CDCHandle dc, PDWR pDWR )
 		MARK_HEIGHT = sg.cy;
 		MARK_GAP = MARK_HEIGHT + 4;
 	}
-	int base_offset =  ((_style.hilited_mark_color & 0xff000000) && !_style.mark_text.empty()) ? MARK_GAP : 0;
+	int base_offset =  ((_style.hilited_mark_color & 0xff000000)) ? MARK_GAP : 0;
 
 	// calc page indicator 
 	CSize pgszl, pgszr;
@@ -237,7 +237,7 @@ void VHorizontalLayout::DoLayoutWithWrap(CDCHandle dc, PDWR pDWR)
 		MARK_HEIGHT = sg.cy;
 		MARK_GAP = MARK_HEIGHT + 4;
 	}
-	int base_offset =  ((_style.hilited_mark_color & 0xff000000) && !_style.mark_text.empty()) ? MARK_GAP : 0;
+	int base_offset =  ((_style.hilited_mark_color & 0xff000000)) ? MARK_GAP : 0;
 
 	// calc page indicator 
 	CSize pgszl, pgszr;

--- a/WeaselUI/VerticalLayout.cpp
+++ b/WeaselUI/VerticalLayout.cpp
@@ -20,7 +20,7 @@ void weasel::VerticalLayout::DoLayout(CDCHandle dc, PDWR pDWR)
 		MARK_HEIGHT = sg.cy;
 		MARK_GAP = MARK_WIDTH + 4;
 	}
-	int base_offset =  ((_style.hilited_mark_color & 0xff000000) && !_style.mark_text.empty()) ? MARK_GAP : 0;
+	int base_offset =  ((_style.hilited_mark_color & 0xff000000)) ? MARK_GAP : 0;
 
 	// calc page indicator 
 	CSize pgszl, pgszr;

--- a/WeaselUI/WeaselPanel.cpp
+++ b/WeaselUI/WeaselPanel.cpp
@@ -436,20 +436,15 @@ bool WeaselPanel::_DrawPreedit(Text const& text, CDCHandle dc, CRect const& rc)
 	IDWriteTextFormat1* txtFormat = pDWR->pPreeditTextFormat.Get();
 
 	if (!t.empty()) {
-		weasel::TextRange range;
-		std::vector<weasel::TextAttribute> const& attrs = text.attributes;
-		for (size_t j = 0; j < attrs.size(); ++j)
-			if (attrs[j].type == weasel::HIGHLIGHTED)
-				range = attrs[j].range;
+		weasel::TextRange range = m_layout->GetPreeditRange();
 
 		if (range.start < range.end) {
-			CSize beforeSz, hilitedSz, afterSz;
 			std::wstring before_str = t.substr(0, range.start);
 			std::wstring hilited_str = t.substr(range.start, range.end);
 			std::wstring after_str = t.substr(range.end);
-			m_layout->GetTextSizeDW(before_str, before_str.length(), txtFormat, pDWR, &beforeSz);
-			m_layout->GetTextSizeDW(hilited_str, hilited_str.length(), txtFormat, pDWR, &hilitedSz);
-			m_layout->GetTextSizeDW(after_str, after_str.length(), txtFormat, pDWR, &afterSz);
+			CSize beforeSz = m_layout->GetBeforeSize();
+			CSize hilitedSz = m_layout->GetHilitedSize();
+			CSize afterSz = m_layout->GetAfterSize();
 
 			int x = rc.left;
 			int y = rc.top;
@@ -528,18 +523,11 @@ bool WeaselPanel::_DrawPreeditBack(Text const& text, CDCHandle dc, CRect const& 
 	IDWriteTextFormat1* txtFormat = pDWR->pPreeditTextFormat.Get();
 
 	if (!t.empty()) {
-		weasel::TextRange range;
-		std::vector<weasel::TextAttribute> const& attrs = text.attributes;
-		for (size_t j = 0; j < attrs.size(); ++j)
-			if (attrs[j].type == weasel::HIGHLIGHTED)
-				range = attrs[j].range;
+		weasel::TextRange range = m_layout->GetPreeditRange();
 
 		if (range.start < range.end) {
-			CSize beforeSz, hilitedSz;
-			std::wstring before_str = t.substr(0, range.start);
-			std::wstring hilited_str = t.substr(range.start, range.end);
-			m_layout->GetTextSizeDW(before_str, before_str.length(), txtFormat, pDWR, &beforeSz);
-			m_layout->GetTextSizeDW(hilited_str, hilited_str.length(), txtFormat, pDWR, &hilitedSz);
+			CSize beforeSz = m_layout->GetBeforeSize();
+			CSize hilitedSz = m_layout->GetHilitedSize();
 
 			int x = rc.left;
 			int y = rc.top;

--- a/WeaselUI/WeaselPanel.cpp
+++ b/WeaselUI/WeaselPanel.cpp
@@ -235,6 +235,7 @@ LRESULT WeaselPanel::OnLeftClicked(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL
 	point.y = GET_Y_LPARAM(lParam);
 
 	// capture
+	if(m_style.click_to_capture)
 	{
 		CRect recth = m_layout->GetCandidateRect((int)m_ctx.cinfo.highlighted);
 		if(m_istorepos)	recth.OffsetRect(0, m_offsetys[m_ctx.cinfo.highlighted]);

--- a/WeaselUI/WeaselPanel.cpp
+++ b/WeaselUI/WeaselPanel.cpp
@@ -76,7 +76,7 @@ WeaselPanel::~WeaselPanel()
 void WeaselPanel::_ResizeWindow()
 {
 	CDCHandle dc = GetDC();
-	m_size = m_layout->GetContentSize();
+	CSize m_size = m_layout->GetContentSize();
 	SetWindowPos(NULL, 0, 0, m_size.cx, m_size.cy, SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOZORDER | SWP_NOREDRAW);
 	ReleaseDC(dc);
 }
@@ -121,16 +121,15 @@ void WeaselPanel::Refresh()
 	// show schema menu status: schema_id == L".default"
 	bool show_schema_menu = m_status.schema_id == L".default";
 	bool margin_negative = (m_style.margin_x < 0 || m_style.margin_y < 0);
-	bool inline_no_candidates = m_style.inline_preedit && (m_ctx.cinfo.candies.size() == 0) && (!show_tips);
 	// when to hide_cadidates?
-	// 1. inline_no_candidates
-	// or
-	// 2. margin_negative, and not in show tips mode( ascii switching / half-full switching / simp-trad switching / error tips), and not in schema menu
+	// 1. margin_negative, and not in show tips mode( ascii switching / half-full switching / simp-trad switching / error tips), and not in schema menu
+	// 2. inline preedit without candidates
+	bool inline_no_candidates = (m_style.inline_preedit && m_candidateCount == 0) && !show_tips;
 	hide_candidates = inline_no_candidates || (margin_negative && !show_tips && !show_schema_menu);
 
-	// only RedrawWindow if no need to hide candidates window
-	if(!hide_candidates)
-	{ 
+	// only RedrawWindow if no need to hide candidates window, or inline_no_candidates
+	if(!hide_candidates || inline_no_candidates)
+	{
 		_InitFontRes();
 		_CreateLayout();
 
@@ -139,11 +138,14 @@ void WeaselPanel::Refresh()
 		ReleaseDC(dc);
 		_ResizeWindow();
 		_RepositionWindow();
-		RedrawWindow();
+		if(m_ctx != m_octx) {
+			m_octx = m_ctx;
+			RedrawWindow();
+		}
 	}
 }
 
-void WeaselPanel::_InitFontRes(void)
+void WeaselPanel::_InitFontRes(bool forced)
 {
 	HMONITOR hMonitor = MonitorFromRect(m_inputPos, MONITOR_DEFAULTTONEAREST);
 	UINT dpiX = 96, dpiY = 96;
@@ -151,7 +153,7 @@ void WeaselPanel::_InitFontRes(void)
 		GetDpiForMonitor(hMonitor, MDT_EFFECTIVE_DPI, &dpiX, &dpiY);
 	// prepare d2d1 resources
 	// if style changed, or dpi changed, or pDWR NULL, re-initialize directwrite resources
-	if ((pDWR == NULL) || (m_ostyle != m_style) || (dpiX != dpi))
+	if (forced || (pDWR == NULL) || (m_ostyle != m_style) || (dpiX != dpi))
 	{
 		pDWR.reset();
 		pDWR = std::make_shared< DirectWriteResources>(m_style, dpiX);
@@ -344,7 +346,11 @@ LRESULT WeaselPanel::OnMouseLeave(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL&
 	return 0;
 }
 
-void WeaselPanel::_HighlightText(CDCHandle &dc, CRect rc, COLORREF color, COLORREF shadowColor, int radius, BackType type = BackType::TEXT, IsToRoundStruct rd = IsToRoundStruct(), COLORREF bordercolor=TRANS_COLOR)
+void WeaselPanel::_HighlightText(CDCHandle &dc, const CRect& rc,
+		const COLORREF& color, const COLORREF& shadowColor, const int& radius,
+		const BackType& type = BackType::TEXT,
+		const IsToRoundStruct& rd = IsToRoundStruct(),
+		const COLORREF& bordercolor=TRANS_COLOR)
 {
 	// Graphics obj with SmoothingMode
 	Gdiplus::Graphics g_back(dc);
@@ -429,7 +435,7 @@ void WeaselPanel::_HighlightText(CDCHandle &dc, CRect rc, COLORREF color, COLORR
 }
 
 // draw preedit text, text only
-bool WeaselPanel::_DrawPreedit(Text const& text, CDCHandle dc, CRect const& rc)
+bool WeaselPanel::_DrawPreedit(const Text& text, CDCHandle dc, const CRect& rc)
 {
 	bool drawn = false;
 	std::wstring const& t = text.str;
@@ -516,7 +522,7 @@ bool WeaselPanel::_DrawPreedit(Text const& text, CDCHandle dc, CRect const& rc)
 }
 
 // draw hilited back color, back only
-bool WeaselPanel::_DrawPreeditBack(Text const& text, CDCHandle dc, CRect const& rc)
+bool WeaselPanel::_DrawPreeditBack(const Text& text, CDCHandle dc, const CRect& rc)
 {
 	bool drawn = false;
 	std::wstring const& t = text.str;
@@ -573,7 +579,12 @@ bool WeaselPanel::_DrawCandidates(CDCHandle &dc, bool back)
 	const std::vector<Text> &candidates(m_ctx.cinfo.candies);
 	const std::vector<Text> &comments(m_ctx.cinfo.comments);
 	const std::vector<Text> &labels(m_ctx.cinfo.labels);
-
+	// prevent all text format nullptr
+	if(pDWR->pTextFormat.Get() == nullptr 
+			&& pDWR->pLabelTextFormat.Get() == nullptr
+			&& pDWR->pCommentTextFormat.Get() == nullptr) {
+		_InitFontRes(true);
+	}
 	ComPtr<IDWriteTextFormat1> txtFormat = pDWR->pTextFormat;
 	ComPtr<IDWriteTextFormat1> labeltxtFormat = pDWR->pLabelTextFormat;
 	ComPtr<IDWriteTextFormat1> commenttxtFormat = pDWR->pCommentTextFormat;
@@ -627,23 +638,23 @@ bool WeaselPanel::_DrawCandidates(CDCHandle &dc, bool back)
 			_HighlightText(dc, rect, m_style.hilited_candidate_back_color, m_style.hilited_candidate_shadow_color, m_style.round_corner, bkType, rd, m_style.hilited_candidate_border_color);
 			if (m_style.mark_text.empty() && COLORNOTTRANSPARENT(m_style.hilited_mark_color))
 			{
-				BYTE r = GetRValue(m_style.hilited_mark_color);
-				BYTE g = GetGValue(m_style.hilited_mark_color);
-				BYTE b = GetBValue(m_style.hilited_mark_color);
-				BYTE alpha = (BYTE)((m_style.hilited_mark_color >> 24) & 255);
+				int height = min(rect.Height() - m_style.hilite_padding_y * 2, rect.Height() - m_style.round_corner * 2);
+				int width = min(rect.Width() - m_style.hilite_padding_x * 2, rect.Width() - m_style.round_corner * 2);
 				Gdiplus::Graphics g_back(dc);
 				g_back.SetSmoothingMode(Gdiplus::SmoothingMode::SmoothingModeHighQuality);
-				Gdiplus::Color mark_color = Gdiplus::Color::MakeARGB(alpha, r, g, b);
+				Gdiplus::Color mark_color = GDPCOLOR_FROM_COLORREF(m_style.hilited_mark_color);
 				Gdiplus::SolidBrush mk_brush(mark_color);
 				if (m_style.layout_type == UIStyle::LAYOUT_VERTICAL_TEXT)
 				{
-					CRect mkrc{ rect.left + m_style.round_corner, rect.top, rect.right - m_style.round_corner, rect.top + m_layout->MARK_HEIGHT / 2 };
+					int x = rect.left + (rect.Width() - width)/2;
+					CRect mkrc{ x, rect.top, x + width, rect.top + m_layout->MARK_HEIGHT / 2 };
 					GraphicsRoundRectPath mk_path(mkrc, 2);
 					g_back.FillPath(&mk_brush, &mk_path);
 				}
 				else
 				{
-					CRect mkrc{ rect.left, rect.top + m_style.round_corner, rect.left + m_layout->MARK_WIDTH / 2, rect.bottom - m_style.round_corner };
+					int y = rect.top + (rect.Height() - height)/2;
+					CRect mkrc{ rect.left, y, rect.left + m_layout->MARK_WIDTH / 2, y + height };
 					GraphicsRoundRectPath mk_path(mkrc, 2);
 					g_back.FillPath(&mk_brush, &mk_path);
 				}
@@ -718,6 +729,8 @@ bool WeaselPanel::_DrawCandidates(CDCHandle &dc, bool back)
 //draw client area
 void WeaselPanel::DoPaint(CDCHandle dc)
 {
+	// turn off WS_EX_TRANSPARENT, for better resp performance
+	ModifyStyleEx(WS_EX_TRANSPARENT, WS_EX_LAYERED);
 	GetClientRect(&rcw);
 	// prepare memDC
 	CDCHandle hdc = ::GetDC(m_hWnd);
@@ -763,7 +776,7 @@ void WeaselPanel::DoPaint(CDCHandle dc)
 			delete[] btmys;
 		}
 		// background and candidates back, hilite back drawing start
-		if (!m_ctx.empty()) {
+		if ((!m_ctx.empty() && !m_style.inline_preedit) || (m_style.inline_preedit && (m_candidateCount || !m_ctx.aux.empty() ))) {
 			CRect backrc = m_layout->GetContentRect();
 			_HighlightText(memDC, backrc, m_style.back_color, m_style.shadow_color, m_style.round_corner_ex, BackType::BACKGROUND, IsToRoundStruct(),  m_style.border_color);
 		}
@@ -783,8 +796,11 @@ void WeaselPanel::DoPaint(CDCHandle dc)
 			drawn |= _DrawCandidates(memDC, true);
 		// background and candidates back, hilite back drawing end
 
-		// begin  texts drawing
-		pDWR->pRenderTarget->BindDC(memDC, &rcw);
+		// begin  texts drawing, if pRenderTarget failed, force to reinit directwrite resources
+		if (FAILED(pDWR->pRenderTarget->BindDC(memDC, &rcw))) {
+			_InitFontRes(true);
+			pDWR->pRenderTarget->BindDC(memDC, &rcw);
+		}
 		pDWR->pRenderTarget->BeginDraw();
 		// draw auxiliary string
 		if (!m_ctx.aux.str.empty())
@@ -822,8 +838,6 @@ void WeaselPanel::DoPaint(CDCHandle dc)
 	}
 	_LayerUpdate(rcw, memDC);
 
-	// turn off WS_EX_TRANSPARENT after drawings, for better resp performance
-	::SetWindowLong(m_hWnd, GWL_EXSTYLE, ::GetWindowLong(m_hWnd, GWL_EXSTYLE) & (~WS_EX_TRANSPARENT));
 	// clean objs
 	::DeleteDC(memDC);
 	::DeleteObject(memBitmap);
@@ -850,9 +864,8 @@ LRESULT WeaselPanel::OnCreate(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHa
 	return TRUE;
 }
 
-LRESULT WeaselPanel::OnDestroy(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled) 
+LRESULT WeaselPanel::OnDestroy(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 { 
-	m_osize = {0,0};
 	delete m_layout;
 	m_layout = NULL;
 	return 0; 
@@ -868,36 +881,34 @@ void WeaselPanel::MoveTo(RECT const& rc)
 {
 	if(!m_layout)	return;			// avoid handling nullptr in _RepositionWindow 
 	// if ascii_tip_follow_cursor set, move tip icon to mouse cursor
-	if(m_style.ascii_tip_follow_cursor && m_ctx.aux.empty() && (!m_status.composing) && m_layout->ShouldDisplayStatusIcon())	// ascii icon
-	{
+	if(m_style.ascii_tip_follow_cursor && m_ctx.empty() 
+			&& (!m_status.composing) && m_layout->ShouldDisplayStatusIcon()) {	
+		// ascii icon follow cursor
 		POINT p;
 		::GetCursorPos(&p);
 		RECT irc{p.x-STATUS_ICON_SIZE, p.y-STATUS_ICON_SIZE, p.x, p.y};
 		m_inputPos = irc;
-		m_oinputPos = irc;
 		_RepositionWindow(true);
 		RedrawWindow();
-	} else 
-	if((rc.left != m_oinputPos.left && rc.bottom != m_oinputPos.bottom)		// pos changed
-		|| rc.left != m_oinputPos.left
-		|| m_size != m_osize
-		|| m_octx != m_ctx
-		|| (m_ctx.preedit.str.empty() && (CRect(rc) == m_oinputPos))		// first click old pos
-		|| !m_ctx.aux.str.empty()	// aux not empty, msg 
-		|| (m_ctx.aux.empty() && (m_layout) && m_layout->ShouldDisplayStatusIcon()))	// ascii icon
-	{
-		m_octx = m_ctx;
-		m_osize = m_size;
+	} else if (!(rc.left == m_inputPos.left && rc.bottom != m_inputPos.bottom 
+				&& abs(rc.bottom - m_inputPos.bottom) < 6)) {
+		// in some apps like word 2021, with inline_preedit set,
+		// bottom of rc would flicker 1 px or 2, make the candidate flickering
 		m_inputPos = rc;
 		m_inputPos.OffsetRect(0, 6);
-		m_oinputPos = m_inputPos;
+		// buffer current m_istorepos status
+		bool m_istorepos_buf = m_istorepos;
 		// with parameter to avoid vertical flicker
 		_RepositionWindow(true);
-		RedrawWindow();
+		// m_istorepos status changed by _RepositionWindow, or tips to show,
+		// redrawing is required
+		if(m_istorepos != m_istorepos_buf || !m_ctx.aux.empty() 
+				|| (m_ctx.empty() && m_layout->ShouldDisplayStatusIcon()))
+			RedrawWindow();
 	}
 }
 
-void WeaselPanel::_RepositionWindow(bool adj)
+void WeaselPanel::_RepositionWindow(const bool& adj)
 {
 	RECT rcWorkArea;
 	memset(&rcWorkArea, 0, sizeof(rcWorkArea));
@@ -918,13 +929,18 @@ void WeaselPanel::_RepositionWindow(bool adj)
 	rcWorkArea.bottom -= height;
 	int x = m_inputPos.left;
 	int y = m_inputPos.bottom;
-	x -= (m_style.shadow_offset_x >= 0 || COLORTRANSPARENT(m_style.shadow_color)) ? m_layout->offsetX : (m_layout->offsetX / 2);
-	if(adj) y -= (m_style.shadow_offset_y > 0 || COLORTRANSPARENT(m_style.shadow_color)) ? m_layout->offsetY : (m_layout->offsetY / 2);
+	if(m_style.shadow_radius)
+	{
+		x -= (m_style.shadow_offset_x >= 0 || COLORTRANSPARENT(m_style.shadow_color)) ? m_layout->offsetX : (m_layout->offsetX / 2);
+		if (adj)
+			y -= (m_style.shadow_offset_y > 0 || COLORTRANSPARENT(m_style.shadow_color)) ? m_layout->offsetY : (m_layout->offsetY / 2);
+	}
 	// for vertical text layout, flow right to left, make window left side
 	if(m_style.layout_type == UIStyle::LAYOUT_VERTICAL_TEXT && !m_style.vertical_text_left_to_right)
 	{
 		x += m_layout->offsetX - width;
-		if ( m_style.shadow_offset_x < 0 ) x += m_layout->offsetX;
+		if (m_style.shadow_offset_x < 0)
+			x += m_layout->offsetX;
 	}
 	if(adj) m_istorepos = false;
 	if (x > rcWorkArea.right) x = rcWorkArea.right;		// over workarea right
@@ -932,18 +948,21 @@ void WeaselPanel::_RepositionWindow(bool adj)
 	// show panel above the input focus if we're around the bottom
 	if (y > rcWorkArea.bottom) {
 		y = m_inputPos.top - height - 6; // over workarea bottom
-		if( !adj && (y + height < m_oinputPos.top) )
-			y = m_oinputPos.top - height;
+		if(m_style.shadow_radius && m_style.shadow_offset_y > 0)
+			y -= m_style.shadow_offset_y;
 		m_istorepos = (m_style.vertical_auto_reverse && m_style.layout_type == UIStyle::LAYOUT_VERTICAL);
-		y += (m_style.shadow_offset_y < 0 || COLORTRANSPARENT(m_style.shadow_color)) ? m_layout->offsetY : (m_layout->offsetY / 2);
-	}
+		if(m_style.shadow_radius > 0)
+			y += (m_style.shadow_offset_y < 0 || COLORTRANSPARENT(m_style.shadow_color)) ? m_layout->offsetY : (m_layout->offsetY / 2);
+	} 
 	if (y < rcWorkArea.top) y = rcWorkArea.top;		// over workarea top
 	// memorize adjusted position (to avoid window bouncing on height change)
 	m_inputPos.bottom = y;
 	SetWindowPos(HWND_TOPMOST, x, y, 0, 0, SWP_NOSIZE | SWP_NOACTIVATE | SWP_NOREDRAW);
 }
 
-void WeaselPanel::_TextOut(CRect const& rc, std::wstring psz, size_t cch, int inColor, IDWriteTextFormat1* pTextFormat)
+void WeaselPanel::_TextOut(const CRect& rc, const std::wstring& psz,
+		const size_t& cch, const int& inColor,
+		IDWriteTextFormat1* const pTextFormat)
 {
 	if (pTextFormat == NULL) return;
 	float r = (float)(GetRValue(inColor))/255.0f;
@@ -960,7 +979,7 @@ void WeaselPanel::_TextOut(CRect const& rc, std::wstring psz, size_t cch, int in
 		pDWR->SetBrushColor(D2D1::ColorF(r, g, b, alpha));
 
 	if (NULL != pDWR->pBrush && NULL != pTextFormat) {
-		pDWR->CreateTextLayout( psz.c_str(), (UINT32)psz.size(), pTextFormat, (float)rc.Width(), (float)rc.Height());
+		pDWR->CreateTextLayout( psz.c_str(), (int)cch, pTextFormat, (float)rc.Width(), (float)rc.Height());
 		if (m_style.layout_type == UIStyle::LAYOUT_VERTICAL_TEXT) {
 			DWRITE_FLOW_DIRECTION flow = m_style.vertical_text_left_to_right ? DWRITE_FLOW_DIRECTION_LEFT_TO_RIGHT : DWRITE_FLOW_DIRECTION_RIGHT_TO_LEFT;
 			pDWR->SetLayoutReadingDirection(DWRITE_READING_DIRECTION_TOP_TO_BOTTOM);

--- a/WeaselUI/WeaselPanel.h
+++ b/WeaselUI/WeaselPanel.h
@@ -56,17 +56,21 @@ public:
 	bool GetIsReposition(){ return m_istorepos; }
 
 private:
-	void _InitFontRes(void);
+	void _InitFontRes(bool forced = false);
 	void _CaptureRect(CRect& rect);
 	bool m_mouse_entry = false;
 	void _CreateLayout();
 	void _ResizeWindow();
-	void _RepositionWindow(bool adj = false);
-	bool _DrawPreedit(weasel::Text const& text, CDCHandle dc, CRect const& rc);
-	bool _DrawPreeditBack(weasel::Text const& text, CDCHandle dc, CRect const& rc);
+	void _RepositionWindow(const bool& adj = false);
+	bool _DrawPreedit(const Text& text, CDCHandle dc,  const CRect& rc);
+	bool _DrawPreeditBack(const Text& text, CDCHandle dc,  const CRect& rc);
 	bool _DrawCandidates(CDCHandle &dc, bool back = false);
-	void _HighlightText(CDCHandle &dc, CRect rc, COLORREF color, COLORREF shadowColor, int radius, BackType type, IsToRoundStruct rd, COLORREF bordercolor);
-	void _TextOut(CRect const& rc, std::wstring psz, size_t cch, int inColor, IDWriteTextFormat1* pTextFormat = NULL);
+	void _HighlightText(CDCHandle &dc, const CRect& rc, const COLORREF& color,
+			const COLORREF& shadowColor, const int& radius,
+			const BackType& type, const IsToRoundStruct& rd,
+			const COLORREF& bordercolor);
+	void _TextOut(const CRect& rc, const std::wstring& psz, const size_t& cch,
+			const int& inColor, IDWriteTextFormat1* const pTextFormat = NULL);
 
 	void _LayerUpdate(const CRect& rc, CDCHandle dc);
 
@@ -78,13 +82,10 @@ private:
 	weasel::UIStyle &m_ostyle;
 
 	CRect m_inputPos;
-	CRect m_oinputPos;
 	int  m_offsetys[MAX_CANDIDATES_COUNT];	// offset y for candidates when vertical layout over bottom
 	int  m_offsety_preedit;
 	int  m_offsety_aux;
 	bool m_istorepos;
-	CSize m_size;
-	CSize m_osize;
 
 	CIcon m_iconDisabled;
 	CIcon m_iconEnabled;

--- a/WeaselUI/WeaselUI.cpp
+++ b/WeaselUI/WeaselUI.cpp
@@ -94,7 +94,7 @@ bool UI::Create(HWND parent)
 {
 	if (pimpl_)
 	{
-		pimpl_->panel.Create(parent, 0, 0, WS_POPUP, WS_EX_TOOLWINDOW | WS_EX_TOPMOST | WS_EX_NOACTIVATE | WS_EX_LAYERED | WS_EX_TRANSPARENT, 0U, 0);
+		pimpl_->panel.Create(parent, 0, 0, WS_POPUP, WS_EX_TOOLWINDOW | WS_EX_TOPMOST | WS_EX_NOACTIVATE | WS_EX_TRANSPARENT, 0U, 0);
 		return true;
 	}
 
@@ -102,7 +102,7 @@ bool UI::Create(HWND parent)
 	if (!pimpl_)
 		return false;
 
-	pimpl_->panel.Create(parent, 0, 0, WS_POPUP, WS_EX_TOOLWINDOW | WS_EX_TOPMOST | WS_EX_NOACTIVATE | WS_EX_LAYERED | WS_EX_TRANSPARENT, 0U, 0);
+	pimpl_->panel.Create(parent, 0, 0, WS_POPUP, WS_EX_TOOLWINDOW | WS_EX_TOPMOST | WS_EX_NOACTIVATE | WS_EX_TRANSPARENT, 0U, 0);
 	return true;
 }
 

--- a/WeaselUI/WeaselUI.cpp
+++ b/WeaselUI/WeaselUI.cpp
@@ -186,5 +186,12 @@ void UI::Update(const Context &ctx, const Status &status)
 {
 	ctx_ = ctx;
 	status_ = status;
+	if(style_.candidate_abbreviate_length > 0) {
+		for (auto& c : ctx_.cinfo.candies) {
+			if (c.str.length() > style_.candidate_abbreviate_length) {
+				c.str = c.str.substr(0, style_.candidate_abbreviate_length - 1) + L"..." + c.str.substr(c.str.length() - 1);
+			}
+		}
+	}
 	Refresh();
 }

--- a/include/WeaselCommon.h
+++ b/include/WeaselCommon.h
@@ -288,6 +288,8 @@ namespace weasel
 		int font_point;
 		int label_font_point;
 		int comment_font_point;
+		int candidate_abbreviate_length;
+
 		bool inline_preedit;
 		bool display_tray_icon;
 		bool ascii_tip_follow_cursor;
@@ -351,6 +353,7 @@ namespace weasel
 			font_point(0),
 			label_font_point(0),
 			comment_font_point(0),
+			candidate_abbreviate_length(0),
 			inline_preedit(false),
 			antialias_mode(DEFAULT),
 			align_type(ALIGN_BOTTOM),
@@ -428,6 +431,7 @@ namespace weasel
 					|| font_point != st.font_point
 					|| label_font_point != st.label_font_point
 					|| comment_font_point != st.comment_font_point
+					|| candidate_abbreviate_length != st.candidate_abbreviate_length
 					|| inline_preedit != st.inline_preedit
 					|| mark_text != st.mark_text
 					|| display_tray_icon != st.display_tray_icon
@@ -494,6 +498,7 @@ namespace boost {
 			ar & s.font_point;
 			ar & s.label_font_point;
 			ar & s.comment_font_point;
+			ar & s.candidate_abbreviate_length;
 			ar & s.inline_preedit;
 			ar & s.align_type;
 			ar & s.antialias_mode;

--- a/include/WeaselCommon.h
+++ b/include/WeaselCommon.h
@@ -274,17 +274,10 @@ namespace weasel
 			ALIGN_TOP
 		};
 
-		AntiAliasMode antialias_mode;
-		LayoutAlignType align_type;
-		PreeditType preedit_type;
-		LayoutType layout_type;
-		bool vertical_text_left_to_right;
-		bool vertical_text_with_wrap;
-		bool paging_on_scroll;
+		// font face and font point settings
 		std::wstring font_face;
 		std::wstring label_font_face;
 		std::wstring comment_font_face;
-		int mouse_hover_ms;
 		int font_point;
 		int label_font_point;
 		int comment_font_point;
@@ -293,16 +286,26 @@ namespace weasel
 		bool inline_preedit;
 		bool display_tray_icon;
 		bool ascii_tip_follow_cursor;
+		bool paging_on_scroll;
+		bool enhanced_position;
 		bool click_to_capture;
+		int mouse_hover_ms;
+		AntiAliasMode antialias_mode;
+		PreeditType preedit_type;
+		// custom icon settings
 		std::wstring current_zhung_icon;
 		std::wstring current_ascii_icon;
 		std::wstring current_half_icon;
 		std::wstring current_full_icon;
-		bool enhanced_position;
-
+		// label format and mark_text
 		std::wstring label_text_format;
 		std::wstring mark_text;
-		// layout
+		// layout relative parameters
+		LayoutType layout_type;
+		LayoutAlignType align_type;
+		bool vertical_text_left_to_right;
+		bool vertical_text_with_wrap;
+		// layout, with key name like style/layout/...
 		int min_width;
 		int max_width;
 		int min_height;
@@ -350,30 +353,29 @@ namespace weasel
 		UIStyle() : font_face(),
 			label_font_face(),
 			comment_font_face(),
-			mouse_hover_ms(0),
 			font_point(0),
 			label_font_point(0),
 			comment_font_point(0),
 			candidate_abbreviate_length(0),
 			inline_preedit(false),
-			antialias_mode(DEFAULT),
-			align_type(ALIGN_BOTTOM),
-			preedit_type(COMPOSITION),
 			display_tray_icon(false),
 			ascii_tip_follow_cursor(false),
+			paging_on_scroll(false),
+			enhanced_position(false),
 			click_to_capture(false),
+			mouse_hover_ms(0),
+			antialias_mode(DEFAULT),
+			preedit_type(COMPOSITION),
 			current_zhung_icon(),
 			current_ascii_icon(),
 			current_half_icon(),
 			current_full_icon(),
-			enhanced_position(false),
-
 			label_text_format(L"%s."),
 			mark_text(),
 			layout_type(LAYOUT_VERTICAL),
+			align_type(ALIGN_BOTTOM),
 			vertical_text_left_to_right(false),
 			vertical_text_with_wrap(false),
-			paging_on_scroll(false),
 			min_width(0),
 			max_width(0),
 			min_height(0),

--- a/include/WeaselCommon.h
+++ b/include/WeaselCommon.h
@@ -293,6 +293,7 @@ namespace weasel
 		bool inline_preedit;
 		bool display_tray_icon;
 		bool ascii_tip_follow_cursor;
+		bool click_to_capture;
 		std::wstring current_zhung_icon;
 		std::wstring current_ascii_icon;
 		std::wstring current_half_icon;
@@ -360,6 +361,7 @@ namespace weasel
 			preedit_type(COMPOSITION),
 			display_tray_icon(false),
 			ascii_tip_follow_cursor(false),
+			click_to_capture(false),
 			current_zhung_icon(),
 			current_ascii_icon(),
 			current_half_icon(),
@@ -441,6 +443,7 @@ namespace weasel
 					|| current_half_icon != st.current_half_icon
 					|| current_full_icon != st.current_full_icon
 					|| enhanced_position != st.enhanced_position
+					|| click_to_capture != st.click_to_capture
 					|| label_text_format != st.label_text_format
 					|| min_width != st.min_width
 					|| max_width != st.max_width
@@ -510,7 +513,8 @@ namespace boost {
 			ar & s.current_ascii_icon;
 			ar & s.current_half_icon;
 			ar & s.current_full_icon;
-			ar& s.enhanced_position;
+			ar & s.enhanced_position;
+			ar & s.click_to_capture;
 			ar & s.label_text_format;
 			// layout
 			ar & s.layout_type;

--- a/include/WeaselCommon.h
+++ b/include/WeaselCommon.h
@@ -176,7 +176,7 @@ namespace weasel
 		}
 		bool operator==(const Context& ctx)
 		{
-			if (preedit == ctx.preedit && aux == ctx.aux || cinfo == ctx.cinfo)
+			if (preedit == ctx.preedit && aux == ctx.aux && cinfo == ctx.cinfo)
 				return true;
 			return false;
 		}

--- a/include/WeaselUI.h
+++ b/include/WeaselUI.h
@@ -103,15 +103,15 @@ namespace weasel
 		DirectWriteResources(weasel::UIStyle& style, UINT dpi);
 		~DirectWriteResources();
 
-		HRESULT InitResources(std::wstring label_font_face, int label_font_point,
-			std::wstring font_face, int font_point,
-			std::wstring comment_font_face, int comment_font_point, bool vertical_text = false);
-		HRESULT InitResources(UIStyle& style, UINT dpi);
+		HRESULT InitResources(const std::wstring& label_font_face, const int& label_font_point,
+			const std::wstring& font_face, const int& font_point,
+			const std::wstring& comment_font_face, const int& comment_font_point, const bool& vertical_text = false);
+		HRESULT InitResources(const UIStyle& style, const UINT& dpi);
 
-		HRESULT CreateTextLayout(std::wstring text, int nCount, IDWriteTextFormat1* txtFormat, float width, float height) {
+		HRESULT CreateTextLayout(const std::wstring& text, const int& nCount,  IDWriteTextFormat1* const txtFormat, const float& width, const float& height) {
 			return pDWFactory->CreateTextLayout(text.c_str(), nCount, txtFormat, width, height, reinterpret_cast<IDWriteTextLayout**>(pTextLayout.GetAddressOf()));
 		}
-		void DrawRect(D2D1_RECT_F* rect,float strokeWidth=1.0f, ID2D1StrokeStyle* sstyle=(ID2D1StrokeStyle*)0) {
+		void DrawRect(D2D1_RECT_F* const rect,const float& strokeWidth=1.0f, ID2D1StrokeStyle* const sstyle=(ID2D1StrokeStyle*)0) {
 			pRenderTarget->DrawRectangle(rect, pBrush.Get(), strokeWidth, sstyle);
 		}
 		HRESULT GetLayoutOverhangMetrics(DWRITE_OVERHANG_METRICS* overhangMetrics) {
@@ -120,23 +120,23 @@ namespace weasel
 		HRESULT GetLayoutMetrics(DWRITE_TEXT_METRICS* metrics) {
 			return pTextLayout->GetMetrics(metrics);
 		}
-		HRESULT SetLayoutReadingDirection(DWRITE_READING_DIRECTION direct) {
+		HRESULT SetLayoutReadingDirection(const DWRITE_READING_DIRECTION& direct) {
 			return pTextLayout->SetReadingDirection(direct);
 		}
-		HRESULT SetLayoutFlowDirection(DWRITE_FLOW_DIRECTION direct) {
+		HRESULT SetLayoutFlowDirection(const DWRITE_FLOW_DIRECTION& direct) {
 			return pTextLayout->SetFlowDirection(direct);
 		}
-		void DrawTextLayoutAt(D2D1_POINT_2F point) {
+		void DrawTextLayoutAt(const D2D1_POINT_2F& point) {
 			pRenderTarget->DrawTextLayout(point, pTextLayout.Get(), pBrush.Get(), D2D1_DRAW_TEXT_OPTIONS_ENABLE_COLOR_FONT);
 		}
-		HRESULT CreateBrush(D2D1_COLOR_F color) {
+		HRESULT CreateBrush(const D2D1_COLOR_F& color) {
 			return pRenderTarget->CreateSolidColorBrush(color, pBrush.GetAddressOf());
 		}
 		void ResetLayout() { pTextLayout.Reset(); }
-		void SetBrushColor(D2D1_COLOR_F color) {
+		void SetBrushColor(const D2D1_COLOR_F& color) {
 			pBrush->SetColor(color);
 		}
-		void SetDpi(UINT dpi);
+		void SetDpi(const UINT& dpi);
 
 		float dpiScaleX_, dpiScaleY_;
 		ComPtr<ID2D1Factory> pD2d1Factory;
@@ -150,7 +150,7 @@ namespace weasel
 		ComPtr<ID2D1SolidColorBrush> pBrush;
 	private:
 		UIStyle& _style;
-		void _ParseFontFace(const std::wstring fontFaceStr, DWRITE_FONT_WEIGHT& fontWeight, DWRITE_FONT_STYLE& fontStyle);
-		void _SetFontFallback(ComPtr<IDWriteTextFormat1> pTextFormat, std::vector<std::wstring> fontVector);
+		void _ParseFontFace(const std::wstring& fontFaceStr, DWRITE_FONT_WEIGHT& fontWeight, DWRITE_FONT_STYLE& fontStyle);
+		void _SetFontFallback(ComPtr<IDWriteTextFormat1> pTextFormat, const std::vector<std::wstring>& fontVector);
 	};
 }

--- a/output/data/weasel.yaml
+++ b/output/data/weasel.yaml
@@ -24,6 +24,7 @@ style:
   font_point: 14
   label_font_point: 14
   comment_font_point: 14
+  candidate_abbreviate_length: 0
   horizontal: false
   fullscreen: false
   inline_preedit: false

--- a/output/data/weasel.yaml
+++ b/output/data/weasel.yaml
@@ -25,6 +25,7 @@ style:
   label_font_point: 14
   comment_font_point: 14
   candidate_abbreviate_length: 0
+  click_to_capture: false
   horizontal: false
   fullscreen: false
   inline_preedit: false


### PR DESCRIPTION
- chore: string type option parsing code rewrite
- fix: typo in WeaselCommon.h
- feat: `style/candidate_abbreviate_length: {int}` to make long candidate abbreviation
- feat: `style/click_to_capture: {bool}`  to determine if to use `click_to_capture` feature
- perf: rewrite layered window redrawing, less redraw esp when candidate window moving.
- fix: attemt to fix empty candidate text issue. #994

known issue: with this pr, situation that couldn't work properly in some app not solved.

make long candidate abbreviated in candidate window, with configuration 
```yaml
  style/candidate_abbreviate_length: 30
```

![image](https://github.com/rime/weasel/assets/4023160/4453a79a-8a89-4294-ba1e-37717f3a1c49)

