### PR TITLE
fix: hilited back 1 px out of back, when hilite_padding equal to margin and border equal to 0

### DIFF
--- a/WeaselUI/WeaselPanel.cpp
+++ b/WeaselUI/WeaselPanel.cpp
@@ -778,6 +778,8 @@ void WeaselPanel::DoPaint(CDCHandle dc)
 		// background and candidates back, hilite back drawing start
 		if ((!m_ctx.empty() && !m_style.inline_preedit) || (m_style.inline_preedit && (m_candidateCount || !m_ctx.aux.empty() ))) {
 			CRect backrc = m_layout->GetContentRect();
+			if (!m_style.border)
+				backrc.InflateRect(1,1);
 			_HighlightText(memDC, backrc, m_style.back_color, m_style.shadow_color, m_style.round_corner_ex, BackType::BACKGROUND, IsToRoundStruct(),  m_style.border_color);
 		}
 		if (!m_ctx.aux.str.empty())


### PR DESCRIPTION
fix: hilited back 1 px out of back, when hilite_padding equal margin and border equal 0.  fix #1056 
