### PR TITLE
docs: update weasel.yaml

### DIFF
--- a/output/data/weasel.yaml
+++ b/output/data/weasel.yaml
@@ -3,80 +3,117 @@
 
 config_version: "0.22"
 
+# 针对特定应用的设置
 app_options:
-  cmd.exe:
-    ascii_mode: true
+  cmd.exe:                # 带 .exe 的进程名：Weasel 15.0 及之前版本须小写; PR #1049 合并后释出的版本大小写不敏感
+    ascii_mode: true      # 英文模式
   conhost.exe:
     ascii_mode: true
+  firefox.exe:
+    inline_preedit: true  # 行内显示预编辑区，规避 <https://github.com/rime/weasel/issues/946>
+  gvim.exe:
+    ascii_mode: true
+    vim_mode: true        # vim 模式
+  windowsterminal.exe:
+    ascii_mode: true
+  wt.exe:
+    ascii_mode: true
+  powershell.exe:
+    ascii_mode: true
+  pwsh.exe:
+    ascii_mode: true
 
-show_notifications: true
-# how long a period notifications shows
-show_notifications_time: 1200
-# use global ascii status
-global_ascii: false
+# 全局设置
+show_notifications: true                   # 是否显示状态变化的通知：true；false
+show_notifications_time: 1200              # 通知显示的时间（ms）
+global_ascii: false                        # 切换为 ascii 模式时，是否影响所有窗口 
 
+# 字体；候选项、候选窗口的行为、布局及样式
 style:
-  antialias_mode: default
-  ascii_tip_follow_cursor: false
-  color_scheme: aqua
-  font_face: Microsoft YaHei
-  label_font_face: Microsoft YaHei
-  comment_font_face: Microsoft YaHei
-  font_point: 14
-  label_font_point: 14
-  comment_font_point: 14
-  candidate_abbreviate_length: 0
-  click_to_capture: false
-  horizontal: false
-  fullscreen: false
-  inline_preedit: false
-  preedit_type: composition
-  display_tray_icon: false
-  label_format: "%s."
-  mark_text: ""
-  mouse_hover_ms: 0
-  paging_on_scroll: false
-  vertical_auto_reverse: false
-  vertical_text: false
-  vertical_text_left_to_right: false
-  vertical_text_with_wrap: false
+  color_scheme: aqua                       # 默认配色方案
+  # color_scheme_dark:                     # 系统为深色模式时，Weasel 的配色方案，Windows 10 1809+ 可用
+
+  label_format: "%s."                      # 标签字符：例如 %s. 效果为 1. 2. 3. ....
+  mark_text: ""                            # 标记字符，显示在选中的候选标签前，需要在配色方案中指定颜色
+  font_face: Microsoft YaHei               # 全局字体
+  label_font_face: Microsoft YaHei         # 标签字体
+  comment_font_face: Microsoft YaHei       # 注释字体
+  font_point: 14                           # 全局字体字号
+  label_font_point: 14                     # 标签字体字号
+  comment_font_point: 14                   # 注释字体字号
+  
+  antialias_mode: default                  # 次像素反锯齿设定：default；force_dword；cleartype；grayscale；aliased
+  ascii_tip_follow_cursor: false           # 切换 ASCII 模式时，提示跟随鼠标，而非输入光标
+  candidate_abbreviate_length: 0           # 候选项略写，超过此字数则用省略号代替。设置为 0 则不启用此功能
+  click_to_capture: false                  # 鼠标点击候选项，创建截图：true；false
+  inline_preedit: false                    # 行内显示预编辑区：true；false
+  preedit_type: composition                # 预编辑区内容：composition（编码）； preview（选中的候选）；preview_all（全部候选）
+  display_tray_icon: false                 # 托盘显示独立于语言栏的额外图标：true；false
+  mouse_hover_ms: 0                        # 鼠标悬停选词响应时间（ms），设置为 0 时禁用该功能
+  paging_on_scroll: false                  # 在候选窗口上滑动滚轮时的行为：true（翻页）；false（选中下一个候选）
+  # enhanced_position: true                # 无法定位候选框时，在窗口左上角显示候选框：true；false
+  
+  horizontal: false                        # 候选项横排：true；false
+  fullscreen: false                        # 候选窗口全屏显示：true；false
+  vertical_text: false                     # 竖排文本：true；false
+  # text_orientation: horizontal           # 文本排列方向，效果和 vertical_text 相同：horizontal；vertical
+  vertical_auto_reverse: false             # 文本竖排模式下，候选窗口位于光标上方时倒序排列：true；false
+  vertical_text_left_to_right: false       # 竖排方向是否从左到右：true；false
+  vertical_text_with_wrap: false           # 文本竖排模式下，自动换行：true；false
+
   layout:
-    align_type: center
-    max_width: 0	#set 0 to disable max width
-    min_width: 160
-    min_height: 0
-    max_height: 0	#set 0 to disable max height
-    border_width: 3
-    margin_x: 12
-    margin_y: 12
-    spacing: 10
-    candidate_spacing: 5
-    hilite_spacing: 4
-    hilite_padding: 2
-    round_corner: 4   #别名 hilited_corner_radius
-    corner_radius: 4
-    shadow_radius: 0
-    shadow_offset_x: 4
-    shadow_offset_y: 4
+    # type: vertical                       # 布局设置，效果和 style 下的设置相同：
+                                           # horizontal（候选项横排）；vertical（候选项竖排） ; vertical_text（竖排文本） ;
+                                           # vertical+fullscreen（竖向全屏） ; horizontal+fullscreen（横向全屏）
+    align_type: center                     # 对齐：top ; center ; bottom
+    max_width: 0                           # 候选框最大宽度，设置为 0 不启用此功能
+    min_width: 160                         # 候选框最小宽度
+    max_height: 0                          # 候选框最大高度
+    min_height: 0                          # 候选框最小高度
+    border_width: 3                        # 边框宽度；别名 border
+    margin_x: 12                           # 主体元素和候选框的左右边距；为负值时，不显示候选框
+    margin_y: 12                           # 主体元素的上下边距；为负值时，不显示候选框
+    spacing: 10                            # inline_preedit 为 false 时，编码区域和候选区域的间距
+    candidate_spacing: 5                   # 候选项之间的间距
+    hilite_spacing: 4                      # 候选项和相应标签的间距
+    hilite_padding: 2                      # 高亮区域和内部文字的间距，影响高亮区域大小
+    # hilite_padding_x: 2                  # 高亮区域和内部文字的左右间距
+    # hilite_padding_y: 2                  # 高亮区域和内部文字的上下间距
+    corner_radius: 4                       # 候选框圆角半径
+    round_corner: 4                        # 高亮区域圆角半径，≤ corner_radius 才能生效；又名 hilited_corner_radius
+    shadow_radius: 0                       # 阴影区域半径，为 0 不显示阴影；需要同时在配色方案中指定非透明的阴影颜色
+    shadow_offset_x: 4                     # 阴影左右偏移距离
+    shadow_offset_y: 4                     # 阴影上下偏移距离
 
+# 配色方案
 preset_color_schemes:
-  aqua:
-    name: 碧水／Aqua
-    author: 佛振 <chen.sst@gmail.com>
-    text_color: 0x000000                          #默认文字颜色
-    back_color: 0xeceeee                          #候选窗背景色
-    shadow_color: 0x00000000                      #候选窗阴影色，默认全透明（无阴影）
-    border_color: 0xe0e0e0                        #候选窗边框颜色
-    hilited_text_color: 0x000000                  #编码文字颜色
-    hilited_back_color: 0xd4d4d4                  #编码背景颜色
-    hilited_shadow_color: 0x00000000              #编码背景块阴影颜色
-    hilited_candidate_text_color: 0xffffff        #高亮候选文字颜色
-    hilited_candidate_back_color: 0xfa3a0a        #高亮候选背景颜色
-    hilited_candidate_shadow_color: 0x00000000    #高亮候选背景块阴影颜色
-    candidate_text_color: 0x000000                #非高亮候选文字颜色
-    candidate_back_color: 0xeceeee                #非高亮候选背景颜色
-    candidate_shadow_color: 0x00000000            #非高亮候选背景块阴影颜色
-
+  aqua:                                           # 在 style/color_schema 指定的配色方案值
+    name: 碧水／Aqua                              # 方案设置中显示的配色名称
+    author: 佛振 <chen.sst@gmail.com>             # 配色作者名称
+    # color_format: abgr                          # 颜色格式：argb；rgba；abgr（默认）
+    text_color: 0x000000                          # 默认文字颜色
+    # comment_text_color: 0x000000                # 注释文字颜色
+    # label_color: 0x000000                       # 标签文字颜色
+    back_color: 0xeceeee                          # 候选窗背景色
+    shadow_color: 0x00000000                      # 候选窗阴影色
+    border_color: 0xe0e0e0                        # 候选窗边框颜色
+    hilited_text_color: 0x000000                  # 编码文字颜色
+    hilited_back_color: 0xd4d4d4                  # 编码背景颜色
+    hilited_shadow_color: 0x00000000              # 编码背景块阴影颜色
+    hilited_candidate_text_color: 0xffffff        # 高亮候选文字颜色
+    hilited_candidate_back_color: 0xfa3a0a        # 高亮候选背景颜色
+    hilited_candidate_shadow_color: 0x00000000    # 高亮候选背景块阴影颜色
+    # hilited_candidate_border_color: 0xe0e0e0    # 高亮候选边框颜色
+    # hilited_label_color: 0x000000               # 高亮候选的标签颜色
+    # hilited_mark_color: 0x000000                # 高亮候选前的标记颜色
+    # hilited_comment_text_color: 0x000000        # 高亮候选的注释颜色
+    candidate_text_color: 0x000000                # 非高亮候选文字颜色
+    candidate_back_color: 0xeceeee                # 非高亮候选背景颜色
+    candidate_shadow_color: 0x00000000            # 非高亮候选背景块阴影颜色
+    # candidate_border_color: 0xe0e0e0            # 非高亮候选的边框颜色
+    # nextpage_color: 0x000000                    # 候选项竖排时的翻页箭头颜色：下一页；不设置则不显示箭头
+    # prevpage_color: 0x000000                    # 候选项竖排时的翻页箭头颜色：上一页；不设置则不显示箭头
+  
   azure:
     name: 青天／Azure
     author: 佛振 <chen.sst@gmail.com>


### PR DESCRIPTION
希望像鼠须管那样，在 weasel.yaml 中直接给出大部分设置的作用和注意事项，如此 PR 所示

- 为 app_options 添加了少量应用配置，一是为了展示三种不同的设置，二是为了解决 Firefox 的输入问题
- style 和配色设置都没有改，但给每一项都添加了说明
- 配色方案中，用注释的方法添加了方案中没有用到的属性

原文档里面有中文繁体、简体还有英文，都改成中文了，不知道是否可以