### PR TITLE
global ascii fix 

### DIFF
--- a/RimeWithWeasel/RimeWithWeasel.cpp
+++ b/RimeWithWeasel/RimeWithWeasel.cpp
@@ -156,6 +156,14 @@ UINT RimeWithWeaselHandler::AddSession(LPWSTR buffer, EatLine eat)
 		if (m_disabled) return 0;
 	}
 	UINT session_id = (UINT)RimeCreateSession();
+	if(m_global_ascii_mode) {
+		for (const auto& pair : m_session_status_map) {
+			if(pair.first) {
+				RimeSetOption(session_id, "ascii_mode", !!pair.second.status.is_ascii_mode);
+				break;
+			}
+		}
+	}
 	DLOG(INFO) << "Add session: created session_id = " << session_id;
 	_ReadClientInfo(session_id, buffer);
 

--- a/WeaselTSF/Compartment.cpp
+++ b/WeaselTSF/Compartment.cpp
@@ -280,6 +280,11 @@ HRESULT WeaselTSF::_HandleCompartment(REFGUID guidCompartment)
 	if (IsEqualGUID(guidCompartment, GUID_COMPARTMENT_KEYBOARD_OPENCLOSE))
 	{
 		BOOL isOpen = _IsKeyboardOpen();
+		// clear composition when close keyboard
+		if (!isOpen && _pEditSessionContext) {
+			m_client.ClearComposition();
+			_EndComposition(_pEditSessionContext, true);
+		}
 		_EnableLanguageBar(isOpen);
 	}
 	else if (IsEqualGUID(guidCompartment, GUID_COMPARTMENT_KEYBOARD_INPUTMODE_CONVERSION))

--- a/WeaselTSF/Compartment.cpp
+++ b/WeaselTSF/Compartment.cpp
@@ -280,9 +280,6 @@ HRESULT WeaselTSF::_HandleCompartment(REFGUID guidCompartment)
 	if (IsEqualGUID(guidCompartment, GUID_COMPARTMENT_KEYBOARD_OPENCLOSE))
 	{
 		BOOL isOpen = _IsKeyboardOpen();
-		if (isOpen) {
-			m_client.TrayCommand(ID_WEASELTRAY_DISABLE_ASCII);
-		}
 		_EnableLanguageBar(isOpen);
 	}
 	else if (IsEqualGUID(guidCompartment, GUID_COMPARTMENT_KEYBOARD_INPUTMODE_CONVERSION))


### PR DESCRIPTION
fix: ascii mode is reset, when adding session, with global_ascii enabled: reuse the previour ascii_mode;

fix: ascii mode is reset, when reopen keyboard (e.g. by Ctrl+Space, or Backspace/Space with keyboard open in Gvim), code lines from #856 . fix #567 #581 

feat: clear composition when close keyboard