### PR TITLE
feat: switch ascii mode by command line

### DIFF
--- a/RimeWithWeasel/RimeWithWeasel.cpp
+++ b/RimeWithWeasel/RimeWithWeasel.cpp
@@ -455,7 +455,19 @@ void RimeWithWeaselHandler::EndMaintenance()
 
 void RimeWithWeaselHandler::SetOption(UINT session_id, const std::string & opt, bool val)
 {
-	RimeSetOption(session_id, opt.c_str(), val);
+	// from no-session client, not actual typing session
+	if (!session_id)
+	{
+		if (m_global_ascii_mode && opt == "ascii_mode")
+		{
+			for (auto& pair : m_session_status_map)
+				RimeSetOption(pair.first, "ascii_mode", val);
+		}
+		else
+			RimeSetOption(m_active_session, opt.c_str(), val);
+	}
+	else
+		RimeSetOption(session_id, opt.c_str(), val);
 }
 
 void RimeWithWeaselHandler::OnUpdateUI(std::function<void()> const &cb)

--- a/WeaselServer/WeaselServer.cpp
+++ b/WeaselServer/WeaselServer.cpp
@@ -75,6 +75,19 @@ int WINAPI _tWinMain(HINSTANCE hInstance, HINSTANCE /*hPrevInstance*/, LPTSTR lp
 		WeaselServerApp::explore(WeaselServerApp::install_dir());
 		return 0;
 	}
+	if (!wcscmp(L"/ascii", lpstrCmdLine) || !wcscmp(L"/nascii", lpstrCmdLine))
+	{
+		weasel::Client client;
+		bool ascii = !wcscmp(L"/ascii", lpstrCmdLine);
+		if (client.Connect())  // try to connect to running server
+		{
+			if (ascii)
+				client.TrayCommand(ID_WEASELTRAY_ENABLE_ASCII);
+			else
+				client.TrayCommand(ID_WEASELTRAY_DISABLE_ASCII);
+		}
+		return 0;
+	}
 
 	// command line option /q stops the running server
 	bool quit = !wcscmp(L"/q", lpstrCmdLine) || !wcscmp(L"/quit", lpstrCmdLine);


### PR DESCRIPTION
switch ascii mode of active session, if `global_ascii` set false
or switch ascii mode of all sessions, if `global_ascii` set true

from command line with `WeaselServer.exe /ascii` or `WeaselServer.exe /nascii`