### PR TITLE
fix: could not restart server by calling `WeaselServer.exe`

### DIFF
--- a/WeaselServer/WeaselServer.cpp
+++ b/WeaselServer/WeaselServer.cpp
@@ -79,14 +79,24 @@ int WINAPI _tWinMain(HINSTANCE hInstance, HINSTANCE /*hPrevInstance*/, LPTSTR lp
 	// command line option /q stops the running server
 	bool quit = !wcscmp(L"/q", lpstrCmdLine) || !wcscmp(L"/quit", lpstrCmdLine);
 	// restart if already running
-	if(quit)
 	{
 		weasel::Client client;
 		if (client.Connect())  // try to connect to running server
 		{
 			client.ShutdownServer();
+			if (quit)
+				return 0;
+			int retry = 0;
+			while (client.Connect() && retry < 10) {
+				client.ShutdownServer();
+				retry++;
+				Sleep(50);
+			}
+			if (retry >= 10)
+				return 0;
 		}
-		return 0;
+		else if (quit)
+			return 0;
 	}
 
 	bool check_updates = !wcscmp(L"/update", lpstrCmdLine);

--- a/WeaselTSF/LanguageBar.cpp
+++ b/WeaselTSF/LanguageBar.cpp
@@ -315,8 +315,6 @@ void WeaselTSF::_HandleLangBarMenuSelect(UINT wID)
 		{
 			std::wstring dir(szValue);
 			std::thread th([dir]() {
-				ShellExecuteW(NULL, L"open", (dir + L"\\stop_service.bat").c_str(), NULL, dir.c_str(), SW_HIDE);
-				Sleep(100);
 				ShellExecuteW(NULL, L"open", (dir + L"\\start_service.bat").c_str(), NULL, dir.c_str(), SW_HIDE);
 				});
 			th.detach();


### PR DESCRIPTION
relative PRs
#956 
#945 

relative issue
#926 

with this PR merged,  restart WeaselServer.exe by calling `WeaselServer.exe` back and ensure
![ascii](https://github.com/rime/weasel/assets/4023160/01a56dd7-56f5-47f7-b2ab-4bc439fb37eb)
