### PR TITLE
fix: Unable to input in Firefox settings interface (workaroud by set inline_preedit) [skip ci]

### DIFF
--- a/output/data/weasel.yaml
+++ b/output/data/weasel.yaml
@@ -8,6 +8,8 @@ app_options:
     ascii_mode: true
   conhost.exe:
     ascii_mode: true
+  firefox.exe:
+    inline_preedit: true # workaround for #946
 
 show_notifications: true
 # how long a period notifications shows


### PR DESCRIPTION
workaround for #946 