### PR TITLE
chore: fix ShowBalloon tip translation follow locale

### DIFF
--- a/WeaselServer/WeaselTrayIcon.cpp
+++ b/WeaselServer/WeaselTrayIcon.cpp
@@ -76,7 +76,11 @@ void WeaselTrayIcon::Refresh() {
       SetIcon(mode_icon[mode]);
 
     if (mode_label[mode] && m_disabled == false) {
-      ShowBalloon(mode_label[mode], WEASEL_IME_NAME);
+      if (GetThreadUILanguage() ==
+          MAKELANGID(LANG_CHINESE, SUBLANG_CHINESE_TRADITIONAL))
+        ShowBalloon(mode_label[mode], WEASEL_IME_NAME);
+      else
+        ShowBalloon(L"维护中", WEASEL_IME_NAME);
       m_disabled = true;
     }
     if (m_mode != DISABLED)


### PR DESCRIPTION
if locale traditional chinese 
![image](https://github.com/rime/weasel/assets/4023160/3ecd3da8-516a-4cb9-97c7-badb843d6b0b)
else
![image](https://github.com/rime/weasel/assets/4023160/34d82106-83cc-483f-bea5-6fcef220261b)

