### PR TITLE
enhance mouse reactions

### DIFF
--- a/RimeWithWeasel/RimeWithWeasel.cpp
+++ b/RimeWithWeasel/RimeWithWeasel.cpp
@@ -1161,8 +1161,6 @@ static void _UpdateUIStyle(RimeConfig* config, UI* ui, bool initialize) {
                           &style.label_font_point, "style/font_point", _abs);
   _RimeGetIntWithFallback(config, "style/comment_font_point",
                           &style.comment_font_point, "style/font_point", _abs);
-  _RimeGetIntWithFallback(config, "style/mouse_hover_ms", &style.mouse_hover_ms,
-                          NULL, _abs);
   _RimeGetIntWithFallback(config, "style/candidate_abbreviate_length",
                           &style.candidate_abbreviate_length, NULL, _abs);
   _RimeGetBool(config, "style/inline_preedit", initialize, style.inline_preedit,
@@ -1185,6 +1183,12 @@ static void _UpdateUIStyle(RimeConfig* config, UI* ui, bool initialize) {
   _RimeParseStringOptWithFallback(config, "style/antialias_mode",
                                   style.antialias_mode, _aliasModeMap,
                                   style.antialias_mode);
+  const std::map<std::string, UIStyle::HoverType> _hoverTypeMap = {
+      {std::string("none"), UIStyle::HoverType::NONE},
+      {std::string("semi_hilite"), UIStyle::HoverType::SEMI_HILITE},
+      {std::string("hilite"), UIStyle::HoverType::HILITE}};
+  _RimeParseStringOptWithFallback(config, "style/hover_type", style.hover_type,
+                                  _hoverTypeMap, style.hover_type);
   const std::map<std::string, UIStyle::LayoutAlignType> _alignType = {
       {std::string("top"), UIStyle::ALIGN_TOP},
       {std::string("center"), UIStyle::ALIGN_CENTER},

--- a/WeaselUI/FullScreenLayout.cpp
+++ b/WeaselUI/FullScreenLayout.cpp
@@ -33,8 +33,13 @@ void weasel::FullScreenLayout::DoLayout(CDCHandle dc, PDWR pDWR) {
                       pDWR->pTextFormat, pDWR, &sg);
       mark_width = sg.cx;
       mark_height = sg.cy;
-      if (_style.mark_text.empty())
+      if (_style.mark_text.empty()) {
         mark_width = mark_height / 7;
+        if (_style.linespacing && _style.baseline)
+          mark_width =
+              (int)((float)mark_width / ((float)_style.linespacing / 100.0f));
+        mark_width = max(mark_width, 6);
+      }
       mark_gap = (_style.mark_text.empty())
                      ? mark_width
                      : mark_width + _style.hilite_spacing;

--- a/WeaselUI/FullScreenLayout.cpp
+++ b/WeaselUI/FullScreenLayout.cpp
@@ -31,13 +31,13 @@ void weasel::FullScreenLayout::DoLayout(CDCHandle dc, PDWR pDWR) {
       else
         GetTextSizeDW(_style.mark_text, _style.mark_text.length(),
                       pDWR->pTextFormat, pDWR, &sg);
-      MARK_WIDTH = sg.cx;
-      MARK_HEIGHT = sg.cy;
+      mark_width = sg.cx;
+      mark_height = sg.cy;
       if (_style.mark_text.empty())
-        MARK_WIDTH = MARK_HEIGHT / 7;
-      MARK_GAP = (_style.mark_text.empty())
-                     ? MARK_WIDTH
-                     : MARK_WIDTH + _style.hilite_spacing;
+        mark_width = mark_height / 7;
+      mark_gap = (_style.mark_text.empty())
+                     ? mark_width
+                     : mark_width + _style.hilite_spacing;
     }
   } while (AdjustFontPoint(dc, workArea, step, pDWR));
 

--- a/WeaselUI/FullScreenLayout.cpp
+++ b/WeaselUI/FullScreenLayout.cpp
@@ -34,7 +34,7 @@ void weasel::FullScreenLayout::DoLayout(CDCHandle dc, PDWR pDWR) {
       MARK_WIDTH = sg.cx;
       MARK_HEIGHT = sg.cy;
       if (_style.mark_text.empty())
-        MARK_WIDTH /= 2;
+        MARK_WIDTH = MARK_HEIGHT / 7;
       MARK_GAP = (_style.mark_text.empty())
                      ? MARK_WIDTH
                      : MARK_WIDTH + _style.hilite_spacing;

--- a/WeaselUI/HorizontalLayout.cpp
+++ b/WeaselUI/HorizontalLayout.cpp
@@ -19,8 +19,13 @@ void HorizontalLayout::DoLayout(CDCHandle dc, PDWR pDWR) {
 
     mark_width = sg.cx;
     mark_height = sg.cy;
-    if (_style.mark_text.empty())
+    if (_style.mark_text.empty()) {
       mark_width = mark_height / 7;
+      if (_style.linespacing && _style.baseline)
+        mark_width =
+            (int)((float)mark_width / ((float)_style.linespacing / 100.0f));
+      mark_width = max(mark_width, 6);
+    }
     mark_gap = (_style.mark_text.empty()) ? mark_width
                                           : mark_width + _style.hilite_spacing;
   }

--- a/WeaselUI/HorizontalLayout.cpp
+++ b/WeaselUI/HorizontalLayout.cpp
@@ -20,7 +20,7 @@ void HorizontalLayout::DoLayout(CDCHandle dc, PDWR pDWR) {
     MARK_WIDTH = sg.cx;
     MARK_HEIGHT = sg.cy;
     if (_style.mark_text.empty())
-      MARK_WIDTH /= 2;
+      MARK_WIDTH = MARK_HEIGHT / 7;
     MARK_GAP = (_style.mark_text.empty()) ? MARK_WIDTH
                                           : MARK_WIDTH + _style.hilite_spacing;
   }

--- a/WeaselUI/HorizontalLayout.cpp
+++ b/WeaselUI/HorizontalLayout.cpp
@@ -17,14 +17,14 @@ void HorizontalLayout::DoLayout(CDCHandle dc, PDWR pDWR) {
       GetTextSizeDW(_style.mark_text, _style.mark_text.length(),
                     pDWR->pTextFormat, pDWR, &sg);
 
-    MARK_WIDTH = sg.cx;
-    MARK_HEIGHT = sg.cy;
+    mark_width = sg.cx;
+    mark_height = sg.cy;
     if (_style.mark_text.empty())
-      MARK_WIDTH = MARK_HEIGHT / 7;
-    MARK_GAP = (_style.mark_text.empty()) ? MARK_WIDTH
-                                          : MARK_WIDTH + _style.hilite_spacing;
+      mark_width = mark_height / 7;
+    mark_gap = (_style.mark_text.empty()) ? mark_width
+                                          : mark_width + _style.hilite_spacing;
   }
-  int base_offset = ((_style.hilited_mark_color & 0xff000000)) ? MARK_GAP : 0;
+  int base_offset = ((_style.hilited_mark_color & 0xff000000)) ? mark_gap : 0;
 
   // calc page indicator
   CSize pgszl, pgszr;

--- a/WeaselUI/Layout.h
+++ b/WeaselUI/Layout.h
@@ -101,9 +101,9 @@ class Layout {
 
   int offsetX = 0;
   int offsetY = 0;
-  int MARK_WIDTH = 4;
-  int MARK_GAP = 8;
-  int MARK_HEIGHT = 0;
+  int mark_width = 4;
+  int mark_gap = 8;
+  int mark_height = 0;
 
  protected:
   const UIStyle& _style;

--- a/WeaselUI/VHorizontalLayout.cpp
+++ b/WeaselUI/VHorizontalLayout.cpp
@@ -22,14 +22,14 @@ void VHorizontalLayout::DoLayout(CDCHandle dc, PDWR pDWR) {
       GetTextSizeDW(_style.mark_text, _style.mark_text.length(),
                     pDWR->pTextFormat, pDWR, &sg);
 
-    MARK_WIDTH = sg.cx;
-    MARK_HEIGHT = sg.cy;
+    mark_width = sg.cx;
+    mark_height = sg.cy;
     if (_style.mark_text.empty())
-      MARK_HEIGHT = MARK_WIDTH / 7;
-    MARK_GAP = (_style.mark_text.empty()) ? MARK_HEIGHT
-                                          : MARK_HEIGHT + _style.hilite_spacing;
+      mark_height = mark_width / 7;
+    mark_gap = (_style.mark_text.empty()) ? mark_height
+                                          : mark_height + _style.hilite_spacing;
   }
-  int base_offset = ((_style.hilited_mark_color & 0xff000000)) ? MARK_GAP : 0;
+  int base_offset = ((_style.hilited_mark_color & 0xff000000)) ? mark_gap : 0;
 
   // calc page indicator
   CSize pgszl, pgszr;
@@ -245,14 +245,14 @@ void VHorizontalLayout::DoLayoutWithWrap(CDCHandle dc, PDWR pDWR) {
       GetTextSizeDW(_style.mark_text, _style.mark_text.length(),
                     pDWR->pTextFormat, pDWR, &sg);
 
-    MARK_WIDTH = sg.cx;
-    MARK_HEIGHT = sg.cy;
+    mark_width = sg.cx;
+    mark_height = sg.cy;
     if (_style.mark_text.empty())
-      MARK_HEIGHT = MARK_WIDTH / 7;
-    MARK_GAP = (_style.mark_text.empty()) ? MARK_HEIGHT
-                                          : MARK_HEIGHT + _style.hilite_spacing;
+      mark_height = mark_width / 7;
+    mark_gap = (_style.mark_text.empty()) ? mark_height
+                                          : mark_height + _style.hilite_spacing;
   }
-  int base_offset = ((_style.hilited_mark_color & 0xff000000)) ? MARK_GAP : 0;
+  int base_offset = ((_style.hilited_mark_color & 0xff000000)) ? mark_gap : 0;
 
   // calc page indicator
   CSize pgszl, pgszr;

--- a/WeaselUI/VHorizontalLayout.cpp
+++ b/WeaselUI/VHorizontalLayout.cpp
@@ -25,7 +25,7 @@ void VHorizontalLayout::DoLayout(CDCHandle dc, PDWR pDWR) {
     MARK_WIDTH = sg.cx;
     MARK_HEIGHT = sg.cy;
     if (_style.mark_text.empty())
-      MARK_HEIGHT /= 2;
+      MARK_HEIGHT = MARK_WIDTH / 7;
     MARK_GAP = (_style.mark_text.empty()) ? MARK_HEIGHT
                                           : MARK_HEIGHT + _style.hilite_spacing;
   }
@@ -248,7 +248,7 @@ void VHorizontalLayout::DoLayoutWithWrap(CDCHandle dc, PDWR pDWR) {
     MARK_WIDTH = sg.cx;
     MARK_HEIGHT = sg.cy;
     if (_style.mark_text.empty())
-      MARK_HEIGHT /= 2;
+      MARK_HEIGHT = MARK_WIDTH / 7;
     MARK_GAP = (_style.mark_text.empty()) ? MARK_HEIGHT
                                           : MARK_HEIGHT + _style.hilite_spacing;
   }

--- a/WeaselUI/VHorizontalLayout.cpp
+++ b/WeaselUI/VHorizontalLayout.cpp
@@ -24,8 +24,13 @@ void VHorizontalLayout::DoLayout(CDCHandle dc, PDWR pDWR) {
 
     mark_width = sg.cx;
     mark_height = sg.cy;
-    if (_style.mark_text.empty())
+    if (_style.mark_text.empty()) {
       mark_height = mark_width / 7;
+      if (_style.linespacing && _style.baseline)
+        mark_height =
+            (int)((float)mark_height / ((float)_style.linespacing / 100.0f));
+      mark_height = max(mark_height, 6);
+    }
     mark_gap = (_style.mark_text.empty()) ? mark_height
                                           : mark_height + _style.hilite_spacing;
   }
@@ -247,8 +252,13 @@ void VHorizontalLayout::DoLayoutWithWrap(CDCHandle dc, PDWR pDWR) {
 
     mark_width = sg.cx;
     mark_height = sg.cy;
-    if (_style.mark_text.empty())
+    if (_style.mark_text.empty()) {
       mark_height = mark_width / 7;
+      if (_style.linespacing && _style.baseline)
+        mark_height =
+            (int)((float)mark_height / ((float)_style.linespacing / 100.0f));
+      mark_height = max(mark_height, 6);
+    }
     mark_gap = (_style.mark_text.empty()) ? mark_height
                                           : mark_height + _style.hilite_spacing;
   }

--- a/WeaselUI/VerticalLayout.cpp
+++ b/WeaselUI/VerticalLayout.cpp
@@ -17,8 +17,13 @@ void weasel::VerticalLayout::DoLayout(CDCHandle dc, PDWR pDWR) {
 
     mark_width = sg.cx;
     mark_height = sg.cy;
-    if (_style.mark_text.empty())
+    if (_style.mark_text.empty()) {
       mark_width = mark_height / 7;
+      if (_style.linespacing && _style.baseline)
+        mark_width =
+            (int)((float)mark_width / ((float)_style.linespacing / 100.0f));
+      mark_width = max(mark_width, 6);
+    }
     mark_gap = (_style.mark_text.empty()) ? mark_width
                                           : mark_width + _style.hilite_spacing;
   }

--- a/WeaselUI/VerticalLayout.cpp
+++ b/WeaselUI/VerticalLayout.cpp
@@ -15,14 +15,14 @@ void weasel::VerticalLayout::DoLayout(CDCHandle dc, PDWR pDWR) {
       GetTextSizeDW(_style.mark_text, _style.mark_text.length(),
                     pDWR->pTextFormat, pDWR, &sg);
 
-    MARK_WIDTH = sg.cx;
-    MARK_HEIGHT = sg.cy;
+    mark_width = sg.cx;
+    mark_height = sg.cy;
     if (_style.mark_text.empty())
-      MARK_WIDTH = MARK_HEIGHT / 7;
-    MARK_GAP = (_style.mark_text.empty()) ? MARK_WIDTH
-                                          : MARK_WIDTH + _style.hilite_spacing;
+      mark_width = mark_height / 7;
+    mark_gap = (_style.mark_text.empty()) ? mark_width
+                                          : mark_width + _style.hilite_spacing;
   }
-  int base_offset = ((_style.hilited_mark_color & 0xff000000)) ? MARK_GAP : 0;
+  int base_offset = ((_style.hilited_mark_color & 0xff000000)) ? mark_gap : 0;
 
   // calc page indicator
   CSize pgszl, pgszr;

--- a/WeaselUI/VerticalLayout.cpp
+++ b/WeaselUI/VerticalLayout.cpp
@@ -18,7 +18,7 @@ void weasel::VerticalLayout::DoLayout(CDCHandle dc, PDWR pDWR) {
     MARK_WIDTH = sg.cx;
     MARK_HEIGHT = sg.cy;
     if (_style.mark_text.empty())
-      MARK_WIDTH /= 2;
+      MARK_WIDTH = MARK_HEIGHT / 7;
     MARK_GAP = (_style.mark_text.empty()) ? MARK_WIDTH
                                           : MARK_WIDTH + _style.hilite_spacing;
   }

--- a/WeaselUI/WeaselPanel.cpp
+++ b/WeaselUI/WeaselPanel.cpp
@@ -803,12 +803,12 @@ bool WeaselPanel::_DrawCandidates(CDCHandle& dc, bool back) {
         Gdiplus::SolidBrush mk_brush(mark_color);
         if (m_style.layout_type == UIStyle::LAYOUT_VERTICAL_TEXT) {
           int x = rect.left + (rect.Width() - width) / 2;
-          CRect mkrc{x, rect.top, x + width, rect.top + m_layout->MARK_HEIGHT};
+          CRect mkrc{x, rect.top, x + width, rect.top + m_layout->mark_height};
           GraphicsRoundRectPath mk_path(mkrc, mkrc.Height() / 2);
           g_back.FillPath(&mk_brush, &mk_path);
         } else {
           int y = rect.top + (rect.Height() - height) / 2;
-          CRect mkrc{rect.left, y, rect.left + m_layout->MARK_WIDTH,
+          CRect mkrc{rect.left, y, rect.left + m_layout->mark_width,
                      y + height};
           GraphicsRoundRectPath mk_path(mkrc, mkrc.Width() / 2);
           g_back.FillPath(&mk_brush, &mk_path);
@@ -869,21 +869,21 @@ bool WeaselPanel::_DrawCandidates(CDCHandle& dc, bool back) {
         if (m_istorepos)
           rc.OffsetRect(0, m_offsetys[m_ctx.cinfo.highlighted]);
         rc.InflateRect(m_style.hilite_padding_x, m_style.hilite_padding_y);
-        int vgap = m_layout->MARK_HEIGHT
-                       ? (rc.Height() - m_layout->MARK_HEIGHT) / 2
+        int vgap = m_layout->mark_height
+                       ? (rc.Height() - m_layout->mark_height) / 2
                        : 0;
         int hgap =
-            m_layout->MARK_WIDTH ? (rc.Width() - m_layout->MARK_WIDTH) / 2 : 0;
+            m_layout->mark_width ? (rc.Width() - m_layout->mark_width) / 2 : 0;
         CRect hlRc;
         if (m_style.layout_type == UIStyle::LAYOUT_VERTICAL_TEXT)
           hlRc =
               CRect(rc.left + hgap, rc.top + m_style.hilite_padding_y,
-                    rc.left + hgap + m_layout->MARK_WIDTH,
-                    rc.top + m_style.hilite_padding_y + m_layout->MARK_HEIGHT);
+                    rc.left + hgap + m_layout->mark_width,
+                    rc.top + m_style.hilite_padding_y + m_layout->mark_height);
         else
           hlRc =
               CRect(rc.left + m_style.hilite_padding_x, rc.top + vgap,
-                    rc.left + m_style.hilite_padding_x + m_layout->MARK_WIDTH,
+                    rc.left + m_style.hilite_padding_x + m_layout->mark_width,
                     rc.bottom - vgap);
         _TextOut(hlRc, m_style.mark_text.c_str(), m_style.mark_text.length(),
                  m_style.hilited_mark_color, pDWR->pTextFormat.Get());

--- a/WeaselUI/WeaselPanel.h
+++ b/WeaselUI/WeaselPanel.h
@@ -30,9 +30,9 @@ class WeaselPanel
   MESSAGE_HANDLER(WM_DESTROY, OnDestroy)
   MESSAGE_HANDLER(WM_DPICHANGED, OnDpiChanged)
   MESSAGE_HANDLER(WM_MOUSEACTIVATE, OnMouseActivate)
-  MESSAGE_HANDLER(WM_LBUTTONDOWN, OnLeftClicked)
+  MESSAGE_HANDLER(WM_LBUTTONUP, OnLeftClickedUp)
+  MESSAGE_HANDLER(WM_LBUTTONDOWN, OnLeftClickedDown)
   MESSAGE_HANDLER(WM_MOUSEWHEEL, OnMouseWheel)
-  MESSAGE_HANDLER(WM_MOUSEHOVER, OnMouseHover)
   MESSAGE_HANDLER(WM_MOUSEMOVE, OnMouseMove)
   MESSAGE_HANDLER(WM_MOUSELEAVE, OnMouseLeave)
   CHAIN_MSG_MAP(CDoubleBufferImpl<WeaselPanel>)
@@ -45,12 +45,15 @@ class WeaselPanel
                           WPARAM wParam,
                           LPARAM lParam,
                           BOOL& bHandled);
-  LRESULT OnLeftClicked(UINT uMsg,
-                        WPARAM wParam,
-                        LPARAM lParam,
-                        BOOL& bHandled);
+  LRESULT OnLeftClickedUp(UINT uMsg,
+                          WPARAM wParam,
+                          LPARAM lParam,
+                          BOOL& bHandled);
+  LRESULT OnLeftClickedDown(UINT uMsg,
+                            WPARAM wParam,
+                            LPARAM lParam,
+                            BOOL& bHandled);
   LRESULT OnMouseWheel(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
-  LRESULT OnMouseHover(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
   LRESULT OnMouseMove(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
   LRESULT OnMouseLeave(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
 
@@ -61,6 +64,13 @@ class WeaselPanel
   void Refresh();
   void DoPaint(CDCHandle dc);
   bool GetIsReposition() { return m_istorepos; }
+
+  static VOID CALLBACK OnTimer(_In_ HWND hwnd,
+                               _In_ UINT uMsg,
+                               _In_ UINT_PTR idEvent,
+                               _In_ DWORD dwTime);
+  static const int AUTOREV_TIMER = 20240315;
+  static UINT_PTR ptimer;
 
  private:
   void _InitFontRes(bool forced = false);
@@ -125,4 +135,6 @@ class WeaselPanel
   PDWR pDWR;
   std::function<void(size_t* const, size_t* const, bool* const, bool* const)>&
       _UICallback;
+  float bar_scale_ = 1.0;
+  int m_hoverIndex = -1;
 };

--- a/include/WeaselCommon.h
+++ b/include/WeaselCommon.h
@@ -203,7 +203,7 @@ struct UIStyle {
   };
 
   enum PreeditType { COMPOSITION, PREVIEW, PREVIEW_ALL };
-
+  enum HoverType { NONE, SEMI_HILITE, HILITE };
   enum LayoutType {
     LAYOUT_VERTICAL = 0,
     LAYOUT_HORIZONTAL,
@@ -230,7 +230,7 @@ struct UIStyle {
   bool paging_on_scroll;
   bool enhanced_position;
   bool click_to_capture;
-  int mouse_hover_ms;
+  HoverType hover_type;
   AntiAliasMode antialias_mode;
   PreeditType preedit_type;
   // custom icon settings
@@ -307,7 +307,7 @@ struct UIStyle {
         paging_on_scroll(false),
         enhanced_position(false),
         click_to_capture(false),
-        mouse_hover_ms(0),
+        hover_type(NONE),
         antialias_mode(DEFAULT),
         preedit_type(COMPOSITION),
         current_zhung_icon(),
@@ -372,7 +372,7 @@ struct UIStyle {
         paging_on_scroll != st.paging_on_scroll || font_face != st.font_face ||
         label_font_face != st.label_font_face ||
         comment_font_face != st.comment_font_face ||
-        mouse_hover_ms != st.mouse_hover_ms || font_point != st.font_point ||
+        hover_type != st.hover_type || font_point != st.font_point ||
         label_font_point != st.label_font_point ||
         comment_font_point != st.comment_font_point ||
         candidate_abbreviate_length != st.candidate_abbreviate_length ||
@@ -432,7 +432,7 @@ void serialize(Archive& ar, weasel::UIStyle& s, const unsigned int version) {
   ar & s.font_face;
   ar & s.label_font_face;
   ar & s.comment_font_face;
-  ar & s.mouse_hover_ms;
+  ar & s.hover_type;
   ar & s.font_point;
   ar & s.label_font_point;
   ar & s.comment_font_point;


### PR DESCRIPTION
 - refactor: drop `style/mouse_hover_ms`, `style/hover_type: {none|semi_hilite|hilite}` to determine hover type, performance enhanced.
- feat: highlight bar and highlight shadow reaction when clicked down;
- fix: mark bar round corner not a fixed 2 pixel
- mark bar weight by 1/7 of height of size of character "|"

close #1156 

`style/hover_type: none`
![none](https://github.com/rime/weasel/assets/4023160/90acee5c-55d5-4853-a607-565fde3ac3de)
`style/hover_type: hilite`
![hilite](https://github.com/rime/weasel/assets/4023160/b2eca016-a270-4cca-85d6-3b528dca285d)
`style/hover_type: semi_hilite`
![semi_hilite](https://github.com/rime/weasel/assets/4023160/865d68ce-bebc-4589-8456-d32d5cf831fd)

