### PR TITLE
fix: async editing flicker, esp example in Word 365[wip]

### DIFF
--- a/WeaselTSF/Composition.cpp
+++ b/WeaselTSF/Composition.cpp
@@ -79,7 +79,7 @@ void WeaselTSF::_StartComposition(com_ptr<ITfContext> pContext,
   if (pStartCompositionEditSession != nullptr) {
     HRESULT hr;
     pContext->RequestEditSession(_tfClientId, pStartCompositionEditSession,
-                                 TF_ES_SYNC | TF_ES_READWRITE, &hr);
+                                 TF_ES_ASYNCDONTCARE | TF_ES_READWRITE, &hr);
   }
 }
 
@@ -126,7 +126,7 @@ void WeaselTSF::_EndComposition(com_ptr<ITfContext> pContext, BOOL clear) {
   if ((pEditSession = new CEndCompositionEditSession(
            this, pContext, _pComposition, clear)) != NULL) {
     pContext->RequestEditSession(_tfClientId, pEditSession,
-                                 TF_ES_SYNC | TF_ES_READWRITE, &hr);
+                                 TF_ES_ASYNCDONTCARE | TF_ES_READWRITE, &hr);
     pEditSession->Release();
   }
 }
@@ -222,7 +222,7 @@ BOOL WeaselTSF::_UpdateCompositionWindow(com_ptr<ITfContext> pContext) {
   }
   HRESULT hr;
   pContext->RequestEditSession(_tfClientId, pEditSession,
-                               TF_ES_SYNC | TF_ES_READ, &hr);
+                               TF_ES_ASYNCDONTCARE | TF_ES_READ, &hr);
   return SUCCEEDED(hr);
 }
 
@@ -384,6 +384,7 @@ void WeaselTSF::_UpdateComposition(com_ptr<ITfContext> pContext) {
 
   _pEditSessionContext->RequestEditSession(
       _tfClientId, this, TF_ES_ASYNCDONTCARE | TF_ES_READWRITE, &hr);
+  _async_edit = !!(hr == TF_S_ASYNC);
   _UpdateCompositionWindow(pContext);
 }
 

--- a/WeaselTSF/KeyEventSink.cpp
+++ b/WeaselTSF/KeyEventSink.cpp
@@ -104,7 +104,8 @@ STDAPI WeaselTSF::OnKeyUp(ITfContext* pContext,
     *pfEaten = TRUE;
   } else {
     _ProcessKeyEvent(wParam, lParam, pfEaten);
-    _UpdateComposition(pContext);
+    if (_async_edit)
+      _UpdateComposition(pContext);
   }
   return S_OK;
 }

--- a/WeaselTSF/KeyEventSink.cpp
+++ b/WeaselTSF/KeyEventSink.cpp
@@ -104,7 +104,7 @@ STDAPI WeaselTSF::OnKeyUp(ITfContext* pContext,
     *pfEaten = TRUE;
   } else {
     _ProcessKeyEvent(wParam, lParam, pfEaten);
-    if (_async_edit)
+    if (!_async_edit)
       _UpdateComposition(pContext);
   }
   return S_OK;

--- a/WeaselTSF/WeaselTSF.h
+++ b/WeaselTSF/WeaselTSF.h
@@ -223,4 +223,5 @@ class WeaselTSF : public ITfTextInputProcessorEx,
 
   // guidatom for the display attibute.
   TfGuidAtom _gaDisplayAttributeInput;
+  BOOL _async_edit = false;
 };

--- a/WeaselUI/WeaselPanel.cpp
+++ b/WeaselUI/WeaselPanel.cpp
@@ -262,8 +262,10 @@ LRESULT WeaselPanel::OnLeftClickedUp(UINT uMsg,
     rect.InflateRect(m_style.hilite_padding_x, m_style.hilite_padding_y);
     if (rect.PtInRect(point)) {
       size_t i = m_ctx.cinfo.highlighted;
-      if (_UICallback)
+      if (_UICallback) {
         _UICallback(&i, NULL, NULL, NULL);
+        DestroyWindow();
+      }
     } else {
       RedrawWindow();
     }


### PR DESCRIPTION
close #1017

key change: 
1) check if hr == TF_S_ASYNC after _UpdateComposition
2) TF_ES_ASYNCDONTCARE when RequestEditSession
3) check if _async_edit true when OnKeyUp, not to _UpdateComposition when _async_edit true.

known issue:
1) sometimes, couldn't select candidate by space but by number 