### PR TITLE
可调整宽度的mark竖线

### DIFF
--- a/WeaselUI/FullScreenLayout.cpp
+++ b/WeaselUI/FullScreenLayout.cpp
@@ -34,7 +34,8 @@ void weasel::FullScreenLayout::DoLayout(CDCHandle dc, PDWR pDWR) {
       MARK_WIDTH = sg.cx;
       MARK_HEIGHT = sg.cy;
       if (_style.mark_text.empty())
-        MARK_WIDTH /= 2;
+        MARK_WIDTH =
+            _style.mark_bar_weight ? _style.mark_bar_weight : MARK_WIDTH / 2;
       MARK_GAP = (_style.mark_text.empty())
                      ? MARK_WIDTH
                      : MARK_WIDTH + _style.hilite_spacing;

--- a/WeaselUI/HorizontalLayout.cpp
+++ b/WeaselUI/HorizontalLayout.cpp
@@ -20,7 +20,8 @@ void HorizontalLayout::DoLayout(CDCHandle dc, PDWR pDWR) {
     MARK_WIDTH = sg.cx;
     MARK_HEIGHT = sg.cy;
     if (_style.mark_text.empty())
-      MARK_WIDTH /= 2;
+      MARK_WIDTH =
+          _style.mark_bar_weight ? _style.mark_bar_weight : MARK_WIDTH / 2;
     MARK_GAP = (_style.mark_text.empty()) ? MARK_WIDTH
                                           : MARK_WIDTH + _style.hilite_spacing;
   }

--- a/WeaselUI/VHorizontalLayout.cpp
+++ b/WeaselUI/VHorizontalLayout.cpp
@@ -25,7 +25,9 @@ void VHorizontalLayout::DoLayout(CDCHandle dc, PDWR pDWR) {
     MARK_WIDTH = sg.cx;
     MARK_HEIGHT = sg.cy;
     if (_style.mark_text.empty())
-      MARK_HEIGHT /= 2;
+      MARK_WIDTH =
+          _style.mark_bar_weight ? _style.mark_bar_weight : MARK_WIDTH / 2;
+
     MARK_GAP = (_style.mark_text.empty()) ? MARK_HEIGHT
                                           : MARK_HEIGHT + _style.hilite_spacing;
   }
@@ -248,7 +250,8 @@ void VHorizontalLayout::DoLayoutWithWrap(CDCHandle dc, PDWR pDWR) {
     MARK_WIDTH = sg.cx;
     MARK_HEIGHT = sg.cy;
     if (_style.mark_text.empty())
-      MARK_HEIGHT /= 2;
+      MARK_WIDTH =
+          _style.mark_bar_weight ? _style.mark_bar_weight : MARK_WIDTH / 2;
     MARK_GAP = (_style.mark_text.empty()) ? MARK_HEIGHT
                                           : MARK_HEIGHT + _style.hilite_spacing;
   }

--- a/WeaselUI/VerticalLayout.cpp
+++ b/WeaselUI/VerticalLayout.cpp
@@ -18,7 +18,8 @@ void weasel::VerticalLayout::DoLayout(CDCHandle dc, PDWR pDWR) {
     MARK_WIDTH = sg.cx;
     MARK_HEIGHT = sg.cy;
     if (_style.mark_text.empty())
-      MARK_WIDTH /= 2;
+      MARK_WIDTH =
+          _style.mark_bar_weight ? _style.mark_bar_weight : MARK_WIDTH / 2;
     MARK_GAP = (_style.mark_text.empty()) ? MARK_WIDTH
                                           : MARK_WIDTH + _style.hilite_spacing;
   }

--- a/include/WeaselCommon.h
+++ b/include/WeaselCommon.h
@@ -264,6 +264,7 @@ struct UIStyle {
   int shadow_radius;
   int shadow_offset_x;
   int shadow_offset_y;
+  int mark_bar_weight;
   bool vertical_auto_reverse;
   // color scheme
   int text_color;
@@ -335,6 +336,7 @@ struct UIStyle {
         shadow_radius(0),
         shadow_offset_x(0),
         shadow_offset_y(0),
+        mark_bar_weight(0),
         vertical_auto_reverse(false),
         text_color(0),
         candidate_text_color(0),
@@ -395,6 +397,7 @@ struct UIStyle {
         shadow_radius != st.shadow_radius ||
         shadow_offset_x != st.shadow_offset_x ||
         shadow_offset_y != st.shadow_offset_y ||
+        mark_bar_weight != st.mark_bar_weight ||
         vertical_auto_reverse != st.vertical_auto_reverse ||
         text_color != st.text_color ||
         candidate_text_color != st.candidate_text_color ||
@@ -468,6 +471,7 @@ void serialize(Archive& ar, weasel::UIStyle& s, const unsigned int version) {
   ar & s.shadow_radius;
   ar & s.shadow_offset_x;
   ar & s.shadow_offset_y;
+  ar & s.mark_bar_weight;
   ar & s.vertical_auto_reverse;
   // color scheme
   ar & s.text_color;


### PR DESCRIPTION
添加配置 **mark_bar_weight**，在 **mark_text** 为空时生效，用于控制竖线宽度，0或不配置时，宽度默认由字体决定

**默认状态**
![image](https://github.com/rime/weasel/assets/7237501/5a938424-bc29-4b25-a9f1-9c5a7f5dc0e8)

**mark_bar_weight: 5**
![image](https://github.com/rime/weasel/assets/7237501/2d379fa0-6887-4dca-8691-2fea813d271b)

**mark_bar_weight: 10**
![image](https://github.com/rime/weasel/assets/7237501/1d2c8331-2b0e-4da0-9bdb-e773c541d7fa)
