### PR TITLE
ci: call build.bat once to fail ci on build error

### DIFF
--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -37,9 +37,6 @@ jobs:
         shell: bash
         run: |
           cp env.vs2019.bat env.bat
-          #librime_id=$(git submodule foreach --quiet 'if [ $name == "librime" ]; then echo `git rev-parse HEAD`; fi')
-          #echo "librime_id is $librime_id"
-          #echo "librime_id=$librime_id" >> $GITHUB_ENV
 
       - name: Cache Boost
         id: cache-boost
@@ -66,47 +63,14 @@ jobs:
         run: |
           .\github.install.bat
 
-      # cache librime
-      #- name: Cache librime
-      #  if: env.librime_build == 'submodule'
-      #  id: cache-librime
-      #  uses: actions/cache@v4
-      #  with:
-      #    path: |
-      #      librime
-      #    key: ${{ runner.os }}-librime-${{ env.librime_id }}-dual
-
-      # build librime if not cached
-      #- name: Build librime
-      #  if: ${{ env.librime_build == 'submodule' && steps.cache-librime.outputs.cache-hit != 'true' }}
-      #  env:
-      #    RIME_PLUGINS: hchunhui/librime-lua lotem/librime-octagram rime/librime-predict
-      #  shell: bash
-      #  run: |
-      #    # load plugins
-      #    pushd librime
-      #    ./action-install-plugins-windows.bat
-      #    popd
-      #    ./build.bat librime
-
-      # build librime if cached
-      #- name: Copy librime built files cached
-      #  if: ${{ env.librime_build == 'submodule' && steps.cache-librime.outputs.cache-hit == 'true' }}
-      #  shell: bash
-      #  run: |
-      #    cp ./librime/dist_x64/lib/rime* ./lib64/
-      #    cp ./librime/dist_x64/lib/rime.dll ./output/
-      #    cp ./librime/dist_x64/include/*.h ./include/
-      #    cp ./librime/dist_Win32/lib/rime* ./lib/
-      #    cp ./librime/dist_Win32/lib/rime.dll ./output/Win32/
+      - name: Build data
+        run: |
+          .\build.bat data
 
       - name: Build Weasel
         id: build_weasel
-        shell: bash
         run: |
-          ./build.bat data
-          ./build.bat hant arm64
-          ./build.bat installer
+          .\build.bat hant arm64 installer
 
       - name: Compress Debug Symbols
         shell: pwsh

--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -27,9 +27,6 @@ jobs:
         shell: bash
         run: |
           cp env.vs2019.bat env.bat
-          #librime_id=$(git submodule foreach --quiet 'if [ $name == "librime" ]; then echo `git rev-parse HEAD`; fi')
-          #echo "librime_id is $librime_id"
-          #echo "librime_id=$librime_id" >> $GITHUB_ENV
 
       # cache boost
       - name: Cache Boost
@@ -57,59 +54,23 @@ jobs:
         run: |
           .\github.install.bat
 
-      # cache librime for nightly build and not stable release
-      #- name: Cache librime
-      #  if: ${{ github.ref == 'refs/heads/master' && env.librime_build == 'submodule' }}
-      #  id: cache-librime
-      #  uses: actions/cache@v4
-      #  with:
-      #    path: |
-      #      librime
-      #    key: ${{ runner.os }}-librime-${{ env.librime_id }}-dual
-
-      # build librime if not cached for nightly build and not stable release
-      #- name: Build librime
-      #  if: ${{ github.ref == 'refs/heads/master' && env.librime_build == 'submodule' && steps.cache-librime.outputs.cache-hit != 'true' }}
-      #  env:
-      #    RIME_PLUGINS: hchunhui/librime-lua lotem/librime-octagram rime/librime-predict
-      #  shell: bash
-      #  run: |
-      #    # load plugins
-      #    pushd librime
-      #    ./action-install-plugins-windows.bat
-      #    popd
-      #    ./build.bat librime
-
-      # build librime if cached
-      #- name: Copy librime built files cached
-      #  if: ${{ github.ref == 'refs/heads/master' && env.librime_build == 'submodule' && steps.cache-librime.outputs.cache-hit == 'true' }}
-      #  shell: bash
-      #  run: |
-      #    cp ./librime/dist_x64/lib/rime* ./lib64/
-      #    cp ./librime/dist_x64/lib/rime.dll ./output/
-      #    cp ./librime/dist_x64/include/*.h ./include/
-      #    cp ./librime/dist_Win32/lib/rime* ./lib/
-      #    cp ./librime/dist_Win32/lib/rime.dll ./output/Win32/
+      - name: Build data
+        run: |
+          .\build.bat data
 
       - name: Build Weasel Release
         id: build_weasel
         if: startsWith(github.ref, 'refs/tags/')
-        shell: bash
         env:
           RELEASE_BUILD: 1
         run: |
-          ./build.bat data
-          ./build.bat hant arm64
-          ./build.bat installer
+          .\build.bat hant arm64 installer
 
       - name: Build Weasel Nightly
         id: build_weasel_nightly
         if: github.ref == 'refs/heads/master'
-        shell: bash
         run: |
-          ./build.bat data
-          ./build.bat hant arm64
-          ./build.bat installer
+          .\build.bat hant arm64 installer
 
       - name: Compress Debug Symbols
         shell: pwsh


### PR DESCRIPTION
in recent pr build I found that `build.bat` reported errors and they were ignored by the ci script.
`build.bat` checks error after every step, but the ci script doesn't.

also removed commented out code. 