### PR TITLE
add parameter for chance to avoid linespacing flickering

### DIFF
--- a/RimeWithWeasel/RimeWithWeasel.cpp
+++ b/RimeWithWeasel/RimeWithWeasel.cpp
@@ -1223,6 +1223,10 @@ static void _UpdateUIStyle(RimeConfig* config, UI* ui, bool initialize) {
     style.layout_type = UIStyle::LAYOUT_VERTICAL_TEXT;
   _RimeGetStringWithFunc(config, "style/label_format", style.label_text_format);
   _RimeGetStringWithFunc(config, "style/mark_text", style.mark_text);
+  _RimeGetIntWithFallback(config, "style/layout/baseline", &style.baseline,
+                          NULL, _abs);
+  _RimeGetIntWithFallback(config, "style/layout/linespacing",
+                          &style.linespacing, NULL, _abs);
   _RimeGetIntWithFallback(config, "style/layout/min_width", &style.min_width,
                           NULL, _abs);
   _RimeGetIntWithFallback(config, "style/layout/max_width", &style.max_width,

--- a/WeaselUI/DirectWriteResources.cpp
+++ b/WeaselUI/DirectWriteResources.cpp
@@ -122,6 +122,9 @@ HRESULT DirectWriteResources::InitResources(
   const std::wstring _mainFontFace = L"_InvalidFontName_";
   DWRITE_FONT_WEIGHT fontWeight = DWRITE_FONT_WEIGHT_NORMAL;
   DWRITE_FONT_STYLE fontStyle = DWRITE_FONT_STYLE_NORMAL;
+  // convert percentage to float
+  float linespacing = dpiScaleX_ * ((float)_style.linespacing / 100.0f);
+  float baseline = dpiScaleX_ * ((float)_style.baseline / 100.0f);
   // setup font weight and font style by the first unit of font_face setting
   // string
   _ParseFontFace(font_face, fontWeight, fontStyle);
@@ -143,6 +146,10 @@ HRESULT DirectWriteResources::InitResources(
     pTextFormat->SetParagraphAlignment(DWRITE_PARAGRAPH_ALIGNMENT_CENTER);
     pTextFormat->SetWordWrapping(wrapping);
     _SetFontFallback(pTextFormat, fontFaceStrVector);
+    if (_style.linespacing && _style.baseline)
+      pTextFormat->SetLineSpacing(DWRITE_LINE_SPACING_METHOD_UNIFORM,
+                                  font_point * linespacing,
+                                  font_point * baseline);
   }
   decltype(fontFaceStrVector)().swap(fontFaceStrVector);
 
@@ -167,6 +174,10 @@ HRESULT DirectWriteResources::InitResources(
         DWRITE_PARAGRAPH_ALIGNMENT_CENTER);
     pPreeditTextFormat->SetWordWrapping(wrapping);
     _SetFontFallback(pPreeditTextFormat, fontFaceStrVector);
+    if (_style.linespacing && _style.baseline)
+      pPreeditTextFormat->SetLineSpacing(DWRITE_LINE_SPACING_METHOD_UNIFORM,
+                                         font_point * linespacing,
+                                         font_point * baseline);
   }
   decltype(fontFaceStrVector)().swap(fontFaceStrVector);
 
@@ -192,6 +203,10 @@ HRESULT DirectWriteResources::InitResources(
     pLabelTextFormat->SetParagraphAlignment(DWRITE_PARAGRAPH_ALIGNMENT_CENTER);
     pLabelTextFormat->SetWordWrapping(wrapping);
     _SetFontFallback(pLabelTextFormat, fontFaceStrVector);
+    if (_style.linespacing && _style.baseline)
+      pLabelTextFormat->SetLineSpacing(DWRITE_LINE_SPACING_METHOD_UNIFORM,
+                                       label_font_point * linespacing,
+                                       label_font_point * baseline);
   }
   decltype(fontFaceStrVector)().swap(fontFaceStrVector);
 
@@ -218,6 +233,10 @@ HRESULT DirectWriteResources::InitResources(
         DWRITE_PARAGRAPH_ALIGNMENT_CENTER);
     pCommentTextFormat->SetWordWrapping(wrapping);
     _SetFontFallback(pCommentTextFormat, fontFaceStrVector);
+    if (_style.linespacing && _style.baseline)
+      pCommentTextFormat->SetLineSpacing(DWRITE_LINE_SPACING_METHOD_UNIFORM,
+                                         comment_font_point * linespacing,
+                                         comment_font_point * baseline);
   }
   decltype(fontFaceStrVector)().swap(fontFaceStrVector);
   return hResult;

--- a/WeaselUI/WeaselPanel.cpp
+++ b/WeaselUI/WeaselPanel.cpp
@@ -1126,8 +1126,8 @@ void WeaselPanel::_TextOut(const CRect& rc,
     if (pDWR->pTextLayout != NULL) {
       pDWR->DrawTextLayoutAt({offsetx, offsety});
 #if 0
-			D2D1_RECT_F rectf =  D2D1::RectF(offsetx, offsety, offsetx + rc.Width(), offsety + rc.Height());
-			pDWR->DrawRect(&rectf);
+      D2D1_RECT_F rectf =  D2D1::RectF(offsetx, offsety, offsetx + rc.Width(), offsety + rc.Height());
+      pDWR->DrawRect(&rectf);
 #endif
     }
     pDWR->ResetLayout();

--- a/include/WeaselCommon.h
+++ b/include/WeaselCommon.h
@@ -290,6 +290,8 @@ struct UIStyle {
   int nextpage_color;
   // per client
   int client_caps;
+  int baseline;
+  int linespacing;
 
   UIStyle()
       : font_face(),
@@ -358,6 +360,8 @@ struct UIStyle {
         hilited_mark_color(0),
         prevpage_color(0),
         nextpage_color(0),
+        baseline(0),
+        linespacing(0),
         client_caps(0) {}
   bool operator!=(const UIStyle& st) {
     return (
@@ -396,6 +400,7 @@ struct UIStyle {
         shadow_offset_x != st.shadow_offset_x ||
         shadow_offset_y != st.shadow_offset_y ||
         vertical_auto_reverse != st.vertical_auto_reverse ||
+        baseline != st.baseline || linespacing != st.linespacing ||
         text_color != st.text_color ||
         candidate_text_color != st.candidate_text_color ||
         candidate_back_color != st.candidate_back_color ||
@@ -494,6 +499,8 @@ void serialize(Archive& ar, weasel::UIStyle& s, const unsigned int version) {
   ar & s.nextpage_color;
   // per client
   ar & s.client_caps;
+  ar & s.baseline;
+  ar & s.linespacing;
 }
 
 template <typename Archive>

--- a/output/data/weasel.yaml
+++ b/output/data/weasel.yaml
@@ -60,6 +60,8 @@ style:
     shadow_radius: 0
     shadow_offset_x: 4
     shadow_offset_y: 4
+    linespacing: 0 # percentage of font point, 0 to disable
+    baseline: 0 # percentage of font point, 0 to disable
 
 preset_color_schemes:
   aqua:


### PR DESCRIPTION
add param: `style/layout/baseline: {int}` and `style/layout/linespacing: {int}`, chance to avoid candidate height/width flickering by adjudging baseline position and linespacing (percentage of font point). default both `0 to disable adjudging`.

fixed: #1175
fixed: #866

patch file example
```yaml
patch:
  style/layout/baseline: 100  # 100% of font point height
  style/layout/linespacing: 140   # 140% of font point height, when flicker happened, should be a value larger than 100
```