### PR TITLE
fix: composition not aborted when WeaselTSF::OnSetFocus(ITfDocumentMgr* pDocMgrFocus, ITfDocumentMgr* pDocMgrPrevFocus) called to HideUI

### DIFF
--- a/WeaselTSF/ThreadMgrEventSink.cpp
+++ b/WeaselTSF/ThreadMgrEventSink.cpp
@@ -18,6 +18,7 @@ STDAPI WeaselTSF::OnSetFocus(ITfDocumentMgr* pDocMgrFocus,
   if ((nullptr != pTfContext) &&
       SUCCEEDED(pTfContext->GetDocumentMgr(&pCandidateListDocumentMgr))) {
     if (pCandidateListDocumentMgr != pDocMgrFocus) {
+      _AbortComposition(true);
       _HideUI();
     } else {
       _ShowUI();


### PR DESCRIPTION
e.g., esp situation is that in Setting App of Windows, composing and click outside and back.

![image](https://github.com/rime/weasel/assets/4023160/17fa27a4-e312-4fb4-adbe-328ebb1951fc)
