### PR TITLE
Revert "fix: composition not aborted when WeaselTSF::OnSetFocus(ITfDocumentMgr* pDocMgrFocus, ITfDocumentMgr* pDocMgrPrevFocus) called to HideUI"

### DIFF
--- a/WeaselTSF/ThreadMgrEventSink.cpp
+++ b/WeaselTSF/ThreadMgrEventSink.cpp
@@ -18,7 +18,6 @@ STDAPI WeaselTSF::OnSetFocus(ITfDocumentMgr* pDocMgrFocus,
   if ((nullptr != pTfContext) &&
       SUCCEEDED(pTfContext->GetDocumentMgr(&pCandidateListDocumentMgr))) {
     if (pCandidateListDocumentMgr != pDocMgrFocus) {
-      _AbortComposition(true);
       _HideUI();
     } else {
       _ShowUI();


### PR DESCRIPTION
Reverts rime/weasel#1182
close #1178 