### PR TITLE
ci: disable nightly build in forked repos

### DIFF
--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -85,7 +85,7 @@ jobs:
 
       # create nightly release
       - name: Create Nightly release
-        if: github.ref == 'refs/heads/master'
+        if: ${{ github.repository == 'rime/weasel' && github.ref == 'refs/heads/master' }}
         uses: 'marvinpinto/action-automatic-releases@latest'
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
https://github.com/rime/librime/pull/846

The forked repos nightly build will waste a myriad of CPU resources.

