### PR TITLE
解决重启服务后，Tray Icon 不能立刻出现的问题

### DIFF
--- a/WeaselServer/WeaselServerApp.cpp
+++ b/WeaselServer/WeaselServerApp.cpp
@@ -21,11 +21,11 @@ int WeaselServerApp::Run() {
   win_sparkle_init();
   m_ui.Create(m_server.GetHWnd());
 
-  tray_icon.Create(m_server.GetHWnd());
-  tray_icon.Refresh();
-
   m_handler->Initialize();
   m_handler->OnUpdateUI([this]() { tray_icon.Refresh(); });
+
+  tray_icon.Create(m_server.GetHWnd());
+  tray_icon.Refresh();
 
   int ret = m_server.Run();
 

--- a/WeaselServer/WeaselTrayIcon.cpp
+++ b/WeaselServer/WeaselTrayIcon.cpp
@@ -29,6 +29,8 @@ BOOL WeaselTrayIcon::Create(HWND hTargetWnd) {
   }
   if (!m_style.display_tray_icon) {
     RemoveIcon();
+  } else {
+    AddIcon();
   }
   return bRet;
 }


### PR DESCRIPTION
在 display_tray_icon 设置为true的情况下，服务重启成功后，图标并不会立刻出现，给人没有启动的错觉，效果如下

**修复前**

![2024-04-17-18-11-01](https://github.com/rime/weasel/assets/7237501/4a85f146-5704-454e-9006-e2daa5c6f05a)

**修复后**

![2024-04-17-17-56-04](https://github.com/rime/weasel/assets/7237501/170ecf28-191c-4ed2-94e3-200a0695d24d)
