### PR TITLE
fix: candidate windows destroied after click_select, event still composing. introduced by #1155

### DIFF
--- a/WeaselUI/WeaselPanel.cpp
+++ b/WeaselUI/WeaselPanel.cpp
@@ -264,7 +264,8 @@ LRESULT WeaselPanel::OnLeftClickedUp(UINT uMsg,
       size_t i = m_ctx.cinfo.highlighted;
       if (_UICallback) {
         _UICallback(&i, NULL, NULL, NULL);
-        DestroyWindow();
+        if (!m_status.composing)
+          DestroyWindow();
       }
     } else {
       RedrawWindow();


### PR DESCRIPTION
fix: #1198 