### PR TITLE
fix layout bugs with params min_height/min_width/linespacing/baseline

### DIFF
--- a/WeaselUI/DirectWriteResources.cpp
+++ b/WeaselUI/DirectWriteResources.cpp
@@ -125,6 +125,8 @@ HRESULT DirectWriteResources::InitResources(
   // convert percentage to float
   float linespacing = dpiScaleX_ * ((float)_style.linespacing / 100.0f);
   float baseline = dpiScaleX_ * ((float)_style.baseline / 100.0f);
+  if (_style.layout_type == UIStyle::LAYOUT_VERTICAL_TEXT)
+    baseline = linespacing / 2;
   // setup font weight and font style by the first unit of font_face setting
   // string
   _ParseFontFace(font_face, fontWeight, fontStyle);

--- a/WeaselUI/HorizontalLayout.cpp
+++ b/WeaselUI/HorizontalLayout.cpp
@@ -201,7 +201,7 @@ void HorizontalLayout::DoLayout(CDCHandle dc, PDWR pDWR) {
   width += real_margin_x;
   height += real_margin_y;
 
-  if (!_context.preedit.str.empty() && candidates_count) {
+  if (candidates_count) {
     width = max(width, _style.min_width);
     height = max(height, _style.min_height);
   }

--- a/WeaselUI/VHorizontalLayout.cpp
+++ b/WeaselUI/VHorizontalLayout.cpp
@@ -207,8 +207,19 @@ void VHorizontalLayout::DoLayout(CDCHandle dc, PDWR pDWR) {
     width -= _style.spacing;
 
   height += real_margin_y;
-  _highlightRect = _candidateRects[id];
+
+  if (candidates_count) {
+    width = max(width, _style.min_width);
+    height = max(height, _style.min_height);
+  }
   UpdateStatusIconLayout(&width, &height);
+  // candidate rectangle always align to bottom side, margin_y to the bottom
+  // edge
+  for (auto i = 0; i < candidates_count && i < MAX_CANDIDATES_COUNT; ++i)
+    _candidateRects[i].bottom =
+        max(_candidateRects[i].bottom, height - real_margin_y);
+
+  _highlightRect = _candidateRects[id];
   _contentSize.SetSize(width + offsetX, height + offsetY);
 
   // calc page indicator
@@ -483,10 +494,11 @@ void VHorizontalLayout::DoLayoutWithWrap(CDCHandle dc, PDWR pDWR) {
 
   width += real_margin_x;
   height += real_margin_y;
-  if (!_context.preedit.str.empty() && !candidates_count) {
+  if (candidates_count) {
     width = max(width, _style.min_width);
     height = max(height, _style.min_height);
   }
+  _highlightRect = _candidateRects[id];
   UpdateStatusIconLayout(&width, &height);
   _contentSize.SetSize(width + 2 * offsetX, height + offsetY);
   _contentRect.SetRect(0, 0, _contentSize.cx, _contentSize.cy);

--- a/WeaselUI/VerticalLayout.cpp
+++ b/WeaselUI/VerticalLayout.cpp
@@ -190,7 +190,7 @@ void weasel::VerticalLayout::DoLayout(CDCHandle dc, PDWR pDWR) {
 
   height += real_margin_y;
 
-  if (!_context.preedit.str.empty() && candidates_count) {
+  if (candidates_count) {
     width = max(width, _style.min_width);
     height = max(height, _style.min_height);
   }


### PR DESCRIPTION
- fix: min_height does not work properly when vertical text layout
- fix: `style/layout/baseline` and  `style/layout/linespacing` do not work properly when vertical text layout
- fix: min_height and min_width do not work properly when predicted