### PR TITLE
fix: language bar icon not updated when thread changed (esp work with global_ascii set )

### DIFF
--- a/WeaselTSF/WeaselTSF.h
+++ b/WeaselTSF/WeaselTSF.h
@@ -160,6 +160,10 @@ class WeaselTSF : public ITfTextInputProcessorEx,
   /* TSF Related */
   BOOL _InitThreadMgrEventSink();
   void _UninitThreadMgrEventSink();
+  // ITfThreadFocusSink
+  BOOL _InitThreadFocusSink();
+  void _UninitThreadFocusSink();
+  DWORD _dwThreadFocusSinkCookie;
 
   BOOL _InitTextEditSink(com_ptr<ITfDocumentMgr> pDocMgr);
 

--- a/WeaselUI/FullScreenLayout.cpp
+++ b/WeaselUI/FullScreenLayout.cpp
@@ -26,11 +26,13 @@ void weasel::FullScreenLayout::DoLayout(CDCHandle dc, PDWR pDWR) {
     m_layout->DoLayout(dc, pDWR);
     if ((_style.hilited_mark_color & 0xff000000)) {
       CSize sg;
-      if (_style.mark_text.empty())
-        GetTextSizeDW(L"|", 1, pDWR->pTextFormat, pDWR, &sg);
-      else
-        GetTextSizeDW(_style.mark_text, _style.mark_text.length(),
-                      pDWR->pTextFormat, pDWR, &sg);
+      if (candidates_count) {
+        if (_style.mark_text.empty())
+          GetTextSizeDW(L"|", 1, pDWR->pTextFormat, pDWR, &sg);
+        else
+          GetTextSizeDW(_style.mark_text, _style.mark_text.length(),
+                        pDWR->pTextFormat, pDWR, &sg);
+      }
       mark_width = sg.cx;
       mark_height = sg.cy;
       if (_style.mark_text.empty()) {

--- a/WeaselUI/HorizontalLayout.cpp
+++ b/WeaselUI/HorizontalLayout.cpp
@@ -11,11 +11,13 @@ void HorizontalLayout::DoLayout(CDCHandle dc, PDWR pDWR) {
   /* calc mark_text sizes */
   if ((_style.hilited_mark_color & 0xff000000)) {
     CSize sg;
-    if (_style.mark_text.empty())
-      GetTextSizeDW(L"|", 1, pDWR->pTextFormat, pDWR, &sg);
-    else
-      GetTextSizeDW(_style.mark_text, _style.mark_text.length(),
-                    pDWR->pTextFormat, pDWR, &sg);
+    if (candidates_count) {
+      if (_style.mark_text.empty())
+        GetTextSizeDW(L"|", 1, pDWR->pTextFormat, pDWR, &sg);
+      else
+        GetTextSizeDW(_style.mark_text, _style.mark_text.length(),
+                      pDWR->pTextFormat, pDWR, &sg);
+    }
 
     mark_width = sg.cx;
     mark_height = sg.cy;
@@ -33,8 +35,10 @@ void HorizontalLayout::DoLayout(CDCHandle dc, PDWR pDWR) {
 
   // calc page indicator
   CSize pgszl, pgszr;
-  GetTextSizeDW(pre, pre.length(), pDWR->pPreeditTextFormat, pDWR, &pgszl);
-  GetTextSizeDW(next, next.length(), pDWR->pPreeditTextFormat, pDWR, &pgszr);
+  if (!IsInlinePreedit()) {
+    GetTextSizeDW(pre, pre.length(), pDWR->pPreeditTextFormat, pDWR, &pgszl);
+    GetTextSizeDW(next, next.length(), pDWR->pPreeditTextFormat, pDWR, &pgszr);
+  }
   bool page_en = (_style.prevpage_color & 0xff000000) &&
                  (_style.nextpage_color & 0xff000000);
   int pgw = page_en ? (pgszl.cx + pgszr.cx + _style.hilite_spacing +

--- a/WeaselUI/VHorizontalLayout.cpp
+++ b/WeaselUI/VHorizontalLayout.cpp
@@ -16,11 +16,13 @@ void VHorizontalLayout::DoLayout(CDCHandle dc, PDWR pDWR) {
 
   if ((_style.hilited_mark_color & 0xff000000)) {
     CSize sg;
-    if (_style.mark_text.empty())
-      GetTextSizeDW(L"|", 1, pDWR->pTextFormat, pDWR, &sg);
-    else
-      GetTextSizeDW(_style.mark_text, _style.mark_text.length(),
-                    pDWR->pTextFormat, pDWR, &sg);
+    if (candidates_count) {
+      if (_style.mark_text.empty())
+        GetTextSizeDW(L"|", 1, pDWR->pTextFormat, pDWR, &sg);
+      else
+        GetTextSizeDW(_style.mark_text, _style.mark_text.length(),
+                      pDWR->pTextFormat, pDWR, &sg);
+    }
 
     mark_width = sg.cx;
     mark_height = sg.cy;
@@ -38,8 +40,10 @@ void VHorizontalLayout::DoLayout(CDCHandle dc, PDWR pDWR) {
 
   // calc page indicator
   CSize pgszl, pgszr;
-  GetTextSizeDW(pre, pre.length(), pDWR->pPreeditTextFormat, pDWR, &pgszl);
-  GetTextSizeDW(next, next.length(), pDWR->pPreeditTextFormat, pDWR, &pgszr);
+  if (!IsInlinePreedit()) {
+    GetTextSizeDW(pre, pre.length(), pDWR->pPreeditTextFormat, pDWR, &pgszl);
+    GetTextSizeDW(next, next.length(), pDWR->pPreeditTextFormat, pDWR, &pgszr);
+  }
   bool page_en = (_style.prevpage_color & 0xff000000) &&
                  (_style.nextpage_color & 0xff000000);
   int pgh = page_en ? pgszl.cy + pgszr.cy + _style.hilite_spacing +
@@ -255,11 +259,13 @@ void VHorizontalLayout::DoLayoutWithWrap(CDCHandle dc, PDWR pDWR) {
 
   if ((_style.hilited_mark_color & 0xff000000)) {
     CSize sg;
-    if (_style.mark_text.empty())
-      GetTextSizeDW(L"|", 1, pDWR->pTextFormat, pDWR, &sg);
-    else
-      GetTextSizeDW(_style.mark_text, _style.mark_text.length(),
-                    pDWR->pTextFormat, pDWR, &sg);
+    if (candidates_count) {
+      if (_style.mark_text.empty())
+        GetTextSizeDW(L"|", 1, pDWR->pTextFormat, pDWR, &sg);
+      else
+        GetTextSizeDW(_style.mark_text, _style.mark_text.length(),
+                      pDWR->pTextFormat, pDWR, &sg);
+    }
 
     mark_width = sg.cx;
     mark_height = sg.cy;
@@ -277,8 +283,10 @@ void VHorizontalLayout::DoLayoutWithWrap(CDCHandle dc, PDWR pDWR) {
 
   // calc page indicator
   CSize pgszl, pgszr;
-  GetTextSizeDW(pre, pre.length(), pDWR->pPreeditTextFormat, pDWR, &pgszl);
-  GetTextSizeDW(next, next.length(), pDWR->pPreeditTextFormat, pDWR, &pgszr);
+  if (!IsInlinePreedit()) {
+    GetTextSizeDW(pre, pre.length(), pDWR->pPreeditTextFormat, pDWR, &pgszl);
+    GetTextSizeDW(next, next.length(), pDWR->pPreeditTextFormat, pDWR, &pgszr);
+  }
   bool page_en = (_style.prevpage_color & 0xff000000) &&
                  (_style.nextpage_color & 0xff000000);
   int pgh = page_en ? pgszl.cy + pgszr.cy + _style.hilite_spacing +

--- a/WeaselUI/VerticalLayout.cpp
+++ b/WeaselUI/VerticalLayout.cpp
@@ -9,11 +9,13 @@ void weasel::VerticalLayout::DoLayout(CDCHandle dc, PDWR pDWR) {
 
   if ((_style.hilited_mark_color & 0xff000000)) {
     CSize sg;
-    if (_style.mark_text.empty())
-      GetTextSizeDW(L"|", 1, pDWR->pTextFormat, pDWR, &sg);
-    else
-      GetTextSizeDW(_style.mark_text, _style.mark_text.length(),
-                    pDWR->pTextFormat, pDWR, &sg);
+    if (candidates_count) {
+      if (_style.mark_text.empty())
+        GetTextSizeDW(L"|", 1, pDWR->pTextFormat, pDWR, &sg);
+      else
+        GetTextSizeDW(_style.mark_text, _style.mark_text.length(),
+                      pDWR->pTextFormat, pDWR, &sg);
+    }
 
     mark_width = sg.cx;
     mark_height = sg.cy;
@@ -31,8 +33,10 @@ void weasel::VerticalLayout::DoLayout(CDCHandle dc, PDWR pDWR) {
 
   // calc page indicator
   CSize pgszl, pgszr;
-  GetTextSizeDW(pre, pre.length(), pDWR->pPreeditTextFormat, pDWR, &pgszl);
-  GetTextSizeDW(next, next.length(), pDWR->pPreeditTextFormat, pDWR, &pgszr);
+  if (!IsInlinePreedit()) {
+    GetTextSizeDW(pre, pre.length(), pDWR->pPreeditTextFormat, pDWR, &pgszl);
+    GetTextSizeDW(next, next.length(), pDWR->pPreeditTextFormat, pDWR, &pgszr);
+  }
   bool page_en = (_style.prevpage_color & 0xff000000) &&
                  (_style.nextpage_color & 0xff000000);
   int pgw = page_en ? pgszl.cx + pgszr.cx + _style.hilite_spacing +

--- a/WeaselUI/WeaselUI.cpp
+++ b/WeaselUI/WeaselUI.cpp
@@ -161,6 +161,8 @@ void UI::UpdateInputPosition(RECT const& rc) {
 }
 
 void UI::Update(const Context& ctx, const Status& status) {
+  if (ctx_ == ctx && status_ == status)
+    return;
   ctx_ = ctx;
   status_ = status;
   if (style_.candidate_abbreviate_length > 0) {

--- a/include/WeaselIPCData.h
+++ b/include/WeaselIPCData.h
@@ -163,6 +163,12 @@ struct Status {
     full_shape = false;
     type = SCHEMA;
   }
+  bool operator==(const Status status) {
+    return (status.schema_name == schema_name &&
+            status.schema_id == schema_id && status.ascii_mode == ascii_mode &&
+            status.composing == composing && status.disabled == disabled &&
+            status.full_shape == full_shape && status.type == type);
+  }
   // 輸入方案
   std::wstring schema_name;
   // 輸入方案 id


### PR DESCRIPTION
- update language bar icon with ITfThreadFocusSink
- filter unnecessary UI  updates, avoiding segfault triggered by frequently update ui in WeaselServer. 

about the segfault, if ui not fixed, it might trigger directwrite nullptr referenced(in RimeWithWeasel ),  when quickly and repeatedly switch between two apps