### PR TITLE
perf: only clean directwrite resources when TSF Deactivate called.

### DIFF
--- a/WeaselTSF/CandidateList.cpp
+++ b/WeaselTSF/CandidateList.cpp
@@ -229,9 +229,14 @@ void CCandidateList::UpdateInputPosition(RECT const& rc) {
 void CCandidateList::Destroy() {
   // EndUI();
   Show(FALSE);
-  _DisposeUIWindowAll();
+  _DisposeUIWindow();
 }
 
+void CCandidateList::DestroyAll() {
+  // EndUI();
+  Show(FALSE);
+  _DisposeUIWindowAll();
+}
 UIStyle& CCandidateList::style() {
   // return _ui->style();
   return _style;

--- a/WeaselTSF/CandidateList.h
+++ b/WeaselTSF/CandidateList.h
@@ -51,6 +51,7 @@ class CCandidateList : public ITfIntegratableCandidateListUIElement,
   void UpdateStyle(const weasel::UIStyle& sty);
   void UpdateInputPosition(RECT const& rc);
   void Destroy();
+  void DestroyAll();
   void StartUI();
   void EndUI();
 

--- a/WeaselTSF/WeaselTSF.cpp
+++ b/WeaselTSF/WeaselTSF.cpp
@@ -114,7 +114,7 @@ STDAPI WeaselTSF::Deactivate() {
 
   _tfClientId = TF_CLIENTID_NULL;
 
-  _cand->Destroy();
+  _cand->DestroyAll();
 
   return S_OK;
 }


### PR DESCRIPTION
  keep  directwrite resources alive when TSF status activated, less object re-creations.