### PR TITLE
ci: bump action-gh-release to v2

### DIFF
--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -97,7 +97,7 @@ jobs:
         
       # create stable release
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |


### PR DESCRIPTION
Node.js 16 停止支持