### PR TITLE
SetThreadPriority  server and client

### DIFF
--- a/WeaselServer/WeaselServer.cpp
+++ b/WeaselServer/WeaselServer.cpp
@@ -124,6 +124,10 @@ int WINAPI _tWinMain(HINSTANCE hInstance,
 
   int nRet = 0;
   try {
+    HANDLE hThread = GetCurrentThread();
+    if (GetThreadPriority(hThread) != THREAD_PRIORITY_ABOVE_NORMAL) {
+      SetThreadPriority(hThread, THREAD_PRIORITY_HIGHEST);
+    }
     WeaselServerApp app;
     RegisterApplicationRestart(NULL, 0);
     nRet = app.Run();

--- a/WeaselTSF/WeaselTSF.cpp
+++ b/WeaselTSF/WeaselTSF.cpp
@@ -176,9 +176,17 @@ STDMETHODIMP WeaselTSF::OnSetThreadFocus() {
     if (ok)
       _UpdateLanguageBar(_status);
   }
+  HANDLE hThread = GetCurrentThread();
+  if (GetThreadPriority(hThread) != THREAD_PRIORITY_ABOVE_NORMAL) {
+    SetThreadPriority(hThread, THREAD_PRIORITY_HIGHEST);
+  }
   return S_OK;
 }
 STDMETHODIMP WeaselTSF::OnKillThreadFocus() {
+  HANDLE hThread = GetCurrentThread();
+  if (GetThreadPriority(hThread) != THREAD_PRIORITY_NORMAL) {
+    SetThreadPriority(hThread, THREAD_PRIORITY_NORMAL);
+  }
   _AbortComposition();
   return S_OK;
 }


### PR DESCRIPTION
perf: SetThreadPriority THREAD_PRIORITY_ABOVE_NORMAL when activated in tsf, and keep server THREAD_PRIORITY_ABOVE_NORMAL.

attempt to fix #1250 @mirtlebot @sanshanjianke