### PR TITLE
Revert "build: update build.bat on building rime, build/cache librime in CI, and provide rime.pdb"

### DIFF
--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -19,7 +19,6 @@ jobs:
     env:
       boost_version: 1.84.0
       BOOST_ROOT: ${{ github.workspace }}\deps\boost_1_84_0
-      librime_build: 'submodule'
     steps:
       - name: Checkout last commit
         uses: actions/checkout@v4
@@ -46,9 +45,6 @@ jobs:
         run: |
           cp env.vs2019.bat env.bat
           echo git_ref_name="$(git describe --always)" >> $GITHUB_ENV
-          librime_id=$(git submodule foreach --quiet 'if [ $name == "librime" ]; then echo `git rev-parse HEAD`; fi')
-          echo "librime_id is $librime_id"
-          echo "librime_id=$librime_id" >> $GITHUB_ENV
 
       - name: Cache Boost
         id: cache-boost
@@ -71,47 +67,9 @@ jobs:
         uses: microsoft/setup-msbuild@v2
 
       # use upper stream released librime files if stable release
-      #- name: Copy Rime files
-      #  run: |
-      #    .\github.install.bat
-
-      # cache librime
-      - name: Cache librime
-        if: env.librime_build == 'submodule'
-        id: cache-librime
-        uses: actions/cache@v4
-        with:
-          path: |
-            librime
-          key: ${{ runner.os }}-librime-${{ env.librime_id }}-dual
-
-      # build librime if not cached
-      - name: Build librime
-        if: ${{ env.librime_build == 'submodule' && steps.cache-librime.outputs.cache-hit != 'true' }}
-        env:
-          RIME_PLUGINS: hchunhui/librime-lua lotem/librime-octagram rime/librime-predict
-        shell: bash
+      - name: Copy Rime files
         run: |
-          # load plugins
-          pushd librime
-          ./action-install-plugins-windows.bat
-          popd
-          ./build.bat librime
-          cp librime/build_x64/bin/Release/rime.pdb output/
-          cp librime/build_Win32/bin/Release/rime.pdb output/Win32
-
-      # copy librime files if cached
-      - name: Copy librime built files cached
-        if: ${{ env.librime_build == 'submodule' && steps.cache-librime.outputs.cache-hit == 'true' }}
-        shell: bash
-        run: |
-          cp ./librime/dist_x64/lib/rime*.lib ./lib64/
-          cp ./librime/dist_x64/lib/rime.dll ./output/
-          cp ./librime/dist_x64/include/*.h ./include/
-          cp ./librime/dist_Win32/lib/rime*.lib ./lib/
-          cp ./librime/dist_Win32/lib/rime.dll ./output/Win32/
-          cp librime/build_x64/bin/Release/rime.pdb output/
-          cp librime/build_Win32/bin/Release/rime.pdb output/Win32
+          .\github.install.bat
 
       - name: Build data
         run: |

--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -16,7 +16,6 @@ jobs:
     env:
       boost_version: 1.84.0
       BOOST_ROOT: ${{ github.workspace }}\deps\boost_1_84_0
-      librime_build: 'submodule'
     steps:
       - name: Checkout last commit
         uses: actions/checkout@v4
@@ -27,10 +26,6 @@ jobs:
         shell: bash
         run: |
           cp env.vs2019.bat env.bat
-          echo git_ref_name="$(git describe --always)" >> $GITHUB_ENV
-          librime_id=$(git submodule foreach --quiet 'if [ $name == "librime" ]; then echo `git rev-parse HEAD`; fi')
-          echo "librime_id is $librime_id"
-          echo "librime_id=$librime_id" >> $GITHUB_ENV
 
       # cache boost
       - name: Cache Boost
@@ -54,47 +49,9 @@ jobs:
         uses: microsoft/setup-msbuild@v2
 
       # use upper stream released librime files if stable release
-      #- name: Copy Rime files
-      #  run: |
-      #    .\github.install.bat
-
-      # cache librime
-      - name: Cache librime
-        if: env.librime_build == 'submodule'
-        id: cache-librime
-        uses: actions/cache@v4
-        with:
-          path: |
-            librime
-          key: ${{ runner.os }}-librime-${{ env.librime_id }}-dual
-
-      # build librime if not cached
-      - name: Build librime
-        if: ${{ env.librime_build == 'submodule' && steps.cache-librime.outputs.cache-hit != 'true' }}
-        env:
-          RIME_PLUGINS: hchunhui/librime-lua lotem/librime-octagram rime/librime-predict
-        shell: bash
+      - name: Copy Rime files
         run: |
-          # load plugins
-          pushd librime
-          ./action-install-plugins-windows.bat
-          popd
-          ./build.bat librime
-          cp librime/build_x64/bin/Release/rime.pdb output/
-          cp librime/build_Win32/bin/Release/rime.pdb output/Win32
-
-      # copy librime files if cached
-      - name: Copy librime built files cached
-        if: ${{ env.librime_build == 'submodule' && steps.cache-librime.outputs.cache-hit == 'true' }}
-        shell: bash
-        run: |
-          cp ./librime/dist_x64/lib/rime*.lib ./lib64/
-          cp ./librime/dist_x64/lib/rime.dll ./output/
-          cp ./librime/dist_x64/include/*.h ./include/
-          cp ./librime/dist_Win32/lib/rime*.lib ./lib/
-          cp ./librime/dist_Win32/lib/rime.dll ./output/Win32/
-          cp librime/build_x64/bin/Release/rime.pdb output/
-          cp librime/build_Win32/bin/Release/rime.pdb output/Win32
+          .\github.install.bat
 
       - name: Build data
         run: |


### PR DESCRIPTION
Reverts rime/weasel#1266

rime.dll can not work properly with `preedit_format` #1268, so now it's not good time to provide `rime.pdb`

fix #1268 
