### PR TITLE
attempt to fix key event issue in Chrome under Windows 11

### DIFF
--- a/WeaselTSF/KeyEventSink.cpp
+++ b/WeaselTSF/KeyEventSink.cpp
@@ -5,8 +5,10 @@
 #include "CandidateList.h"
 
 void WeaselTSF::_ProcessKeyEvent(WPARAM wParam, LPARAM lParam, BOOL* pfEaten) {
-  if (!_IsKeyboardOpen())
+  if (!_IsKeyboardOpen() || _IsKeyboardDisabled()) {
+    *pfEaten = FALSE;
     return;
+  }
 
   _EnsureServerConnected();
   weasel::KeyEvent ke;


### PR DESCRIPTION
attempt to fix #1162, fix #997