### PR TITLE
fix: if IPC serialization exception happens, client app would crash cause no exception handler provided.

### DIFF
--- a/WeaselIPC/ContextUpdater.cpp
+++ b/WeaselIPC/ContextUpdater.cpp
@@ -73,7 +73,7 @@ void ContextUpdater::_StoreCand(Deserializer::KeyType k,
   std::wstringstream ss(value);
   boost::archive::text_wiarchive ia(ss);
 
-  ia >> cinfo;
+  TryDeserialize(ia, cinfo);
 
   for (auto& cand : cinfo.candies)
     cand.str = unescape_string(cand.str);

--- a/WeaselIPC/Deserializer.h
+++ b/WeaselIPC/Deserializer.h
@@ -4,6 +4,16 @@
 
 namespace weasel {
 
+template <typename T>
+void TryDeserialize(boost::archive::text_wiarchive& ia, T& t) {
+  try {
+    ia >> t;
+  } catch (const boost::archive::archive_exception& e) {
+    const std::string msg =
+        std::string("boost::archive::archive_exception: ") + e.what();
+    MessageBoxA(NULL, msg.c_str(), "IPC exception", MB_OK | MB_ICONERROR);
+  }
+}
 class Deserializer {
  public:
   typedef std::vector<std::wstring> KeyType;

--- a/WeaselIPC/Styler.cpp
+++ b/WeaselIPC/Styler.cpp
@@ -17,7 +17,7 @@ void Styler::Store(weasel::Deserializer::KeyType const& key,
   std::wstringstream ss(value);
   boost::archive::text_wiarchive ia(ss);
 
-  ia >> sty;
+  TryDeserialize(ia, sty);
 }
 
 weasel::Deserializer::Ptr Styler::Create(weasel::ResponseParser* pTarget) {


### PR DESCRIPTION
esp when newer server to work with old ime/dll