### PR TITLE
feat: Caps_Lock binding available

### DIFF
--- a/WeaselTSF/Composition.cpp
+++ b/WeaselTSF/Composition.cpp
@@ -404,6 +404,7 @@ void WeaselTSF::_AbortComposition(bool clear) {
   if (_IsComposing()) {
     _EndComposition(_pEditSessionContext, clear);
   }
+  _committed = TRUE;
   _cand->Destroy();
 }
 

--- a/WeaselTSF/EditSession.cpp
+++ b/WeaselTSF/EditSession.cpp
@@ -25,6 +25,9 @@ STDAPI WeaselTSF::DoEditSession(TfEditCookie ec) {
       }
       _InsertText(_pEditSessionContext, commit);
       _EndComposition(_pEditSessionContext, false);
+      _committed = TRUE;
+    } else {
+      _committed = FALSE;
     }
     if (_status.composing && !_IsComposing()) {
       _StartComposition(_pEditSessionContext,

--- a/WeaselTSF/WeaselTSF.h
+++ b/WeaselTSF/WeaselTSF.h
@@ -231,4 +231,5 @@ class WeaselTSF : public ITfTextInputProcessorEx,
   // guidatom for the display attibute.
   TfGuidAtom _gaDisplayAttributeInput;
   BOOL _async_edit = false;
+  BOOL _committed = false;
 };


### PR DESCRIPTION
- ability to use  `Caps_Lock` in `key_binder/bindings`


example to binding `Caps_Lock` to `4` when `has_menu`, to select the 4th candidate

```yaml
patch:
  # ensure key_binder is processed before ascii_composer
  engine/processors/@before 0: key_binder
  key_binder/bindings/+:
    # Caps_Lock selecting 4
    - { accept: Caps_Lock, send: 4, when: has_menu} 
    - { accept: Release+Caps_Lock, send: Release+4, when: has_menu}
```