### PR TITLE
build: xmake optional

### DIFF
--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -14,17 +14,11 @@ on:
   pull_request:
 
 jobs:
-  build:
+  lint:
     runs-on: windows-2019
-    env:
-      boost_version: 1.84.0
-      BOOST_ROOT: ${{ github.workspace }}\deps\boost_1_84_0
     steps:
       - name: Checkout last commit
         uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
       - name: Install llvm if necessary
         shell: pwsh
         run: |
@@ -48,10 +42,26 @@ jobs:
             Write-Host "clang-format not installed"
             choco install llvm --version=18.1.6
           }
-
       - name: Code style lint
         shell: bash
         run: ./clang-format.sh -i
+
+  build:
+    needs: lint
+    runs-on: windows-2019
+    env:
+      boost_version: 1.84.0
+      BOOST_ROOT: ${{ github.workspace }}\deps\boost_1_84_0
+    steps:
+
+      - name: Checkout last commit
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+          fetch-depth: 0
+
+      - name: Fetch all tags
+        run: git fetch --tags
 
       - name: Configure build environment
         shell: bash
@@ -67,7 +77,6 @@ jobs:
             ${{ env.BOOST_ROOT }}
           key: ${{ runner.os }}-boost-${{ env.boost_version }}
 
-      # install boost if not cached
       - name: Install Boost
         if: steps.cache-boost.outputs.cache-hit != 'true'
         shell: bash
@@ -75,11 +84,9 @@ jobs:
           ./install_boost.bat
           ./build.bat boost arm64
 
-      # add msbuild to PATH
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v2
 
-      # use upper stream released librime files if stable release
       - name: Copy Rime files
         run: |
           .\github.install.bat
@@ -106,3 +113,66 @@ jobs:
           path: |
             .\output\archives\weasel*.exe
             .\output\archives\debug_symbols.7z
+
+  xbuild:
+    needs: lint
+    runs-on: windows-2019
+    env:
+      boost_version: 1.84.0
+      BOOST_ROOT: ${{ github.workspace }}\deps\boost_1_84_0
+    steps:
+
+      - name: Checkout last commit
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+          fetch-depth: 0
+
+      - name: Fetch all tags
+        run: git fetch --tags
+
+      - name: Configure build environment
+        shell: bash
+        run: |
+          cp env.vs2019.bat env.bat
+          echo git_ref_name="$(git describe --always)" >> $GITHUB_ENV
+
+      - name: Cache Boost
+        id: cache-boost
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ env.BOOST_ROOT }}
+          key: ${{ runner.os }}-boost-${{ env.boost_version }}
+
+      - name: Install Boost
+        if: steps.cache-boost.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          ./install_boost.bat
+          ./build.bat boost arm64
+
+      # xmake 2.9.4 or later
+      - uses: xmake-io/github-action-setup-xmake@v1
+        with:
+          xmake-version: '2.9.4'
+          actions-cache-folder: '.xmake-cache'
+
+      - uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Copy Rime files
+        shell: pwsh
+        run: |
+          .\github.install.bat
+
+      - name: Build data
+        run: |
+          $ErrorActionPreference = 'Stop'
+          .\build.bat data
+
+      - name: Build Weasel
+        id: build_weasel
+        shell: cmd
+        run: |
+          .\xbuild.bat arm64 installer
+

--- a/RimeWithWeasel/xmake.lua
+++ b/RimeWithWeasel/xmake.lua
@@ -1,0 +1,5 @@
+target("RimeWithWeasel")
+  set_kind("static")
+  add_files("./*.cpp")
+  add_rules("use_weaselconstants")
+

--- a/WeaselDeployer/xmake.lua
+++ b/WeaselDeployer/xmake.lua
@@ -1,0 +1,24 @@
+target("WeaselDeployer")
+  set_kind("binary")
+  add_files("./*.cpp")
+  add_rules("add_rcfiles", "use_weaselconstants", "subwin")
+  add_links("imm32", "kernel32", "rime")
+  add_deps("WeaselIPC", "RimeWithWeasel")
+  add_files("$(projectdir)/PerMonitorHighDPIAware.manifest")
+  add_ldflags("/DEBUG /OPT:ICF /LARGEADDRESSAWARE /ERRORREPORT:QUEUE")
+  before_build(function(target)
+    local target_dir = path.join(target:targetdir(), target:name())
+    if not os.exists(target_dir) then
+      os.mkdir(target_dir)
+    end
+    target:set("targetdir", target_dir)
+  end)
+  after_build(function(target)
+    if is_arch("x86") then
+      os.cp(path.join(target:targetdir(), "WeaselDeployer.exe"), "$(projectdir)/output/Win32")
+      os.cp(path.join(target:targetdir(), "WeaselDeployer.pdb"), "$(projectdir)/output/Win32")
+    else
+      os.cp(path.join(target:targetdir(), "WeaselDeployer.exe"), "$(projectdir)/output")
+      os.cp(path.join(target:targetdir(), "WeaselDeployer.pdb"), "$(projectdir)/output")
+    end
+  end)

--- a/WeaselIME/xmake.lua
+++ b/WeaselIME/xmake.lua
@@ -1,0 +1,30 @@
+target("WeaselIME")
+  set_kind("shared")
+  add_files("./*.cpp")
+  add_rules("add_rcfiles")
+  add_links("advapi32", "imm32", "user32", "gdi32")
+  add_deps("WeaselIPC", "WeaselUI")
+  local fname = ''
+
+  before_build(function(target)
+    local target_dir = path.join(target:targetdir(), target:name())
+    if not os.exists(target_dir) then
+      os.mkdir(target_dir)
+    end
+    target:set("targetdir", target_dir)
+  end)
+
+  after_build(function(target)
+    os.cp(path.join(target:targetdir(), "*.ime"), "$(projectdir)/output")
+  end)
+  if is_arch("x86") then
+    fname = "weasel.ime"
+  elseif is_arch("x64") then
+    fname = "weaselx64.ime"
+  elseif is_arch("arm") then
+    fname = "weaselARM.ime"
+  elseif is_arch("arm64") then
+    fname = "weaselARM64.ime"
+  end
+  set_filename(fname)
+

--- a/WeaselIPC/xmake.lua
+++ b/WeaselIPC/xmake.lua
@@ -1,0 +1,4 @@
+target("WeaselIPC")
+  set_kind("static")
+  add_files("./*.cpp")
+

--- a/WeaselIPCServer/xmake.lua
+++ b/WeaselIPCServer/xmake.lua
@@ -1,0 +1,4 @@
+target("WeaselIPCServer")
+  set_kind("static")
+  add_files("./*.cpp")
+

--- a/WeaselServer/xmake.lua
+++ b/WeaselServer/xmake.lua
@@ -1,0 +1,27 @@
+target("WeaselServer")
+  set_kind("binary")
+  add_files("./*.cpp")
+  add_rules("add_rcfiles", "subwin")
+  add_links("imm32", "kernel32", "rime")
+  add_deps("WeaselUI", "WeaselIPC", "RimeWithWeasel", "WeaselIPCServer")
+
+  add_files("$(projectdir)/PerMonitorHighDPIAware.manifest")
+  add_ldflags("/DEBUG /OPT:REF /OPT:ICF /LARGEADDRESSAWARE /ERRORREPORT:QUEUE")
+  set_policy("windows.manifest.uac", "invoker")
+  before_build(function(target)
+    local target_dir = path.join(target:targetdir(), target:name())
+    if not os.exists(target_dir) then
+      os.mkdir(target_dir)
+    end
+    target:set("targetdir", target_dir)
+  end)
+  after_build(function(target)
+    if is_arch("x86") then
+      os.cp(path.join(target:targetdir(), "WeaselServer.exe"), "$(projectdir)/output/Win32")
+      os.cp(path.join(target:targetdir(), "WeaselServer.pdb"), "$(projectdir)/output/Win32")
+    else
+      os.cp(path.join(target:targetdir(), "WeaselServer.exe"), "$(projectdir)/output")
+      os.cp(path.join(target:targetdir(), "WeaselServer.pdb"), "$(projectdir)/output")
+    end
+  end)
+

--- a/WeaselSetup/xmake.lua
+++ b/WeaselSetup/xmake.lua
@@ -1,0 +1,33 @@
+target("WeaselSetup")
+  set_kind("binary")
+  add_files("./*.cpp")
+  add_rules("add_rcfiles", "use_weaselconstants", "subwin")
+  add_links("imm32", "kernel32")
+
+  set_policy("windows.manifest.uac", "admin")
+  add_files("$(projectdir)/PerMonitorHighDPIAware.manifest")
+  add_ldflags("/DEBUG /OPT:REF /OPT:ICF /LARGEADDRESSAWARE /ERRORREPORT:QUEUE")
+
+  before_build(function(target)
+    local target_dir = path.join(target:targetdir(), target:name())
+    if not os.exists(target_dir) then
+      os.mkdir(target_dir)
+    end
+    target:set("targetdir", target_dir)
+    local level = target:policy("windows.manifest.uac")
+    if level then
+      local level_maps = {
+        invoker = "asInvoker",
+        admin = "requireAdministrator",
+        highest = "highestAvailable"
+      }
+      assert(level_maps[level], "unknown uac level %s, please set invoker, admin or highest", level)
+      local ui = target:policy("windows.manifest.uac.ui") or false
+      target:add("ldflags", "/manifest:embed", {("/manifestuac:level='%s' uiAccess='%s'"):format(level_maps[level], ui)}, {force = true, expand = false})
+    end
+  end)
+
+  after_build(function(target)
+      os.cp(path.join(target:targetdir(), "WeaselSetup.exe"), "$(projectdir)/output")
+      os.cp(path.join(target:targetdir(), "WeaselSetup.pdb"), "$(projectdir)/output")
+  end)

--- a/WeaselTSF/xmake.lua
+++ b/WeaselTSF/xmake.lua
@@ -1,0 +1,31 @@
+target("WeaselTSF")
+  set_kind("shared")
+  add_files("./*.cpp", "WeaselTSF.def")
+  add_rules("add_rcfiles", "use_weaselconstants")
+  add_deps("WeaselIPC", "WeaselUI")
+  local fname = ''
+  if is_arch("x86") then
+    fname = "weasel.dll"
+  elseif is_arch("x64") then
+    fname = "weaselx64.dll"
+  elseif is_arch("arm") then
+    fname = "weaselARM.dll"
+  elseif is_arch("arm64") then
+    fname = "weaselARM64.dll"
+  end
+  set_filename(fname)
+
+  add_files("$(projectdir)/PerMonitorHighDPIAware.manifest")
+  add_shflags("/DEBUG /OPT:REF /OPT:ICF")
+  before_build(function(target)
+    local target_dir = path.join(target:targetdir(), target:name())
+    if not os.exists(target_dir) then
+      os.mkdir(target_dir)
+    end
+    target:set("targetdir", target_dir)
+  end)
+
+  after_build(function(target)
+    os.cp(path.join(target:targetdir(), "weasel*.dll"), "$(projectdir)/output")
+    os.cp(path.join(target:targetdir(), "weasel*.pdb"), "$(projectdir)/output")
+  end)

--- a/WeaselUI/xmake.lua
+++ b/WeaselUI/xmake.lua
@@ -1,0 +1,4 @@
+target("WeaselUI")
+  set_kind("static")
+  add_files("./*.cpp")
+

--- a/install-clang-format.bat
+++ b/install-clang-format.bat
@@ -2,17 +2,17 @@
 
 if "%PROCESSOR_ARCHITECTURE%"=="AMD64" (
     rem 64 bit system
-    rem powershell -Command "(New-Object Net.WebClient).DownloadFile('https://github.com/llvm/llvm-project/releases/download/llvmorg-17.0.6/LLVM-17.0.6-win64.exe', 'LLVM-17.0.6-win64.exe')"
-    rem LLVM-17.0.6-win64.exe /S
+    rem powershell -Command "(New-Object Net.WebClient).DownloadFile('https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.6/LLVM-18.1.6-win64.exe', 'LLVM-18.1.6-win64.exe')"
+    rem LLVM-18.1.6-win64.exe /S
     rem or maybe
-    rem output/7z.exe e LLVM-17.0.6-win64.exe bin/clang-format.exe -o.
-    rem rm LLVM-17.0.6-win64.exe
+    rem output/7z.exe e LLVM-18.1.6-win64.exe bin/clang-format.exe -o.
+    rem rm LLVM-18.1.6-win64.exe
 ) else (
     rem 32 bit system
-    rem powershell -Command "(New-Object Net.WebClient).DownloadFile('https://github.com/llvm/llvm-project/releases/download/llvmorg-17.0.6/LLVM-17.0.6-win32.exe', 'LLVM-17.0.6-win32.exe')"
-    rem LLVM-17.0.6-win32.exe /S
+    rem powershell -Command "(New-Object Net.WebClient).DownloadFile('https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.6/LLVM-18.1.6-win32.exe', 'LLVM-18.1.6-win32.exe')"
+    rem LLVM-18.1.6-win32.exe /S
     rem or maybe
-    rem output/7z.exe e LLVM-17.0.6-win32.exe bin/clang-format.exe -o.
-    rem rm LLVM-17.0.6-win32.exe
+    rem output/7z.exe e LLVM-18.1.6-win32.exe bin/clang-format.exe -o.
+    rem rm LLVM-18.1.6-win32.exe
 )
 pause

--- a/test/TestResponseParser/xmake.lua
+++ b/test/TestResponseParser/xmake.lua
@@ -1,0 +1,12 @@
+target("TestResponseParser")
+  set_kind("binary")
+  add_files("./*.cpp")
+  add_deps("WeaselIPC", "WeaselIPCServer")
+  add_rules("subcmd")
+  before_build(function(target)
+    local target_dir = path.join(target:targetdir(), target:name())
+    if not os.exists(target_dir) then
+      os.mkdir(target_dir)
+    end
+    target:set("targetdir", target_dir)
+  end)

--- a/test/TestWeaselIPC/xmake.lua
+++ b/test/TestWeaselIPC/xmake.lua
@@ -1,0 +1,12 @@
+target("TestWeaselIPC")
+  set_kind("binary")
+  add_files("./*.cpp")
+  add_deps("WeaselIPC", "WeaselIPCServer")
+  add_rules("subcmd")
+  before_build(function(target)
+    local target_dir = path.join(target:targetdir(), target:name())
+    if not os.exists(target_dir) then
+      os.mkdir(target_dir)
+    end
+    target:set("targetdir", target_dir)
+  end)

--- a/xbuild.bat
+++ b/xbuild.bat
@@ -121,7 +121,11 @@ if exist output\weaselserver.exe (
 
 rem build booost
 if %build_boost% == 1 (
-  call build.bat boost
+  if %build_arm64% == 1 (
+    call build.bat boost arm64
+  ) else (
+    call build.bat boost
+  )
   if errorlevel 1 exit /b 1
   cd /d %WEASEL_ROOT%
   exit /b

--- a/xbuild.bat
+++ b/xbuild.bat
@@ -100,6 +100,7 @@ set build_commands=0
     set build_weasel=1
     set build_installer=1
     set build_arm64=1
+    set build_commands=1
   )
   shift
   goto parse_cmdline_options
@@ -110,8 +111,9 @@ if %build_boost% == 0 (
 if %build_data% == 0 (
 if %build_opencc% == 0 (
 if %build_rime% == 0 (
+if %build_commands% == 0 (
   set build_weasel=1
-)))))
+))))))
 rem 
 rem quit WeaselServer.exe before building
 cd /d %WEASEL_ROOT%
@@ -128,34 +130,31 @@ if %build_boost% == 1 (
   )
   if errorlevel 1 exit /b 1
   cd /d %WEASEL_ROOT%
-  exit /b
 )
 if %build_rime% == 1 (
   call build.bat rime
   if errorlevel 1 exit /b 1
   cd /d %WEASEL_ROOT%
-  exit /b
 )
 if %build_data% == 1 (
   call build.bat data
   if errorlevel 1 exit /b 1
   cd /d %WEASEL_ROOT%
-  exit /b
 )
 if %build_opencc% == 1 (
   call build.bat opencc
   if errorlevel 1 exit /b 1
   cd /d %WEASEL_ROOT%
-  exit /b
 )
 
 if %build_commands% == 1 (
+  echo Generating compile_commands.json
   xmake project -k compile_commands -m %build_config%
-  exit /b
 )
 
 rem if to clean
 if %build_clean% == 1 ( goto clean )
+if %build_weasel% == 0 ( goto end )
 
 if %build_arm64% == 1 (
   xmake f -a arm64 -m %build_config%

--- a/xbuild.bat
+++ b/xbuild.bat
@@ -1,0 +1,212 @@
+@echo off
+setlocal enabledelayedexpansion
+if not defined include (
+  echo You should run this inside Developer Command Promt!
+  exit /b
+)
+for %%a in ("%include:;=" "%") do (
+  echo %%a| findstr /r "ATLMFC\\include" > nul
+  if not errorlevel 1 (
+    set "atl_lib_dir=%%a"
+    set dpi_manifest=!atl_lib_dir:ATLMFC\include=Include\Manifest\PerMonitorHighDPIAware.manifest!
+    if not exist ".\PerMonitorHighDPIAware.manifest" (
+      copy ""!dpi_manifest!"" .\
+    )
+  )
+)
+rem ---------------------------------------------------------------------------
+if not exist env.bat copy env.bat.template env.bat
+if exist env.bat call env.bat
+set PRODUCT_VERSION=
+if not defined WEASEL_ROOT set WEASEL_ROOT=%CD%
+if not defined VERSION_MAJOR set VERSION_MAJOR=0
+if not defined VERSION_MINOR set VERSION_MINOR=16
+if not defined VERSION_PATCH set VERSION_PATCH=1
+
+if not defined WEASEL_VERSION set WEASEL_VERSION=%VERSION_MAJOR%.%VERSION_MINOR%.%VERSION_PATCH%
+if not defined WEASEL_BUILD set WEASEL_BUILD=0
+
+rem use numeric build version for release build
+set PRODUCT_VERSION=%WEASEL_VERSION%.%WEASEL_BUILD%
+rem for non-release build, try to use git commit hash as product build version
+if not defined RELEASE_BUILD (
+  rem check if git is installed and available, then get the short commit id of head
+  git --version >nul 2>&1
+  if not errorlevel 1 (
+    for /f "delims=" %%i in ('git tag --sort=-creatordate ^| findstr /r "^0."') do (
+      set LAST_TAG=%%i
+      goto found_tag
+    )
+    :found_tag
+    for /f "delims=" %%i in ('git rev-list %LAST_TAG%..HEAD --count') do (
+      set WEASEL_BUILD=%%i
+    )
+    rem get short commmit id of head
+    for /F %%i in ('git rev-parse --short HEAD') do (set PRODUCT_VERSION=%WEASEL_VERSION%.%WEASEL_BUILD%.%%i)
+  )
+)
+
+rem FILE_VERSION is always 4 numbers; same as PRODUCT_VERSION in release build
+if not defined FILE_VERSION set FILE_VERSION=%WEASEL_VERSION%.%WEASEL_BUILD%
+echo PRODUCT_VERSION=%PRODUCT_VERSION%
+echo WEASEL_VERSION=%WEASEL_VERSION%
+echo WEASEL_BUILD=%WEASEL_BUILD%
+echo WEASEL_ROOT=%WEASEL_ROOT%
+echo WEASEL_BUNDLED_RECIPES=%WEASEL_BUNDLED_RECIPES%
+echo BOOST_ROOT=%BOOST_ROOT%
+rem ---------------------------------------------------------------------------
+rem parse the command line options
+set build_config=release
+set build_rebuild=0
+set build_boost=0
+set boost_build_variant=release
+set build_data=0
+set build_opencc=0
+set build_rime=0
+set rime_build_variant=release
+set build_weasel=0
+set build_installer=0
+set build_arm64=0
+set build_clean=0
+set build_commands=0
+:parse_cmdline_options
+  if "%1" == "" goto end_parsing_cmdline_options
+  if "%1" == "debug" (
+    set build_config=debug
+    set boost_build_variant=debug
+    set rime_build_variant=debug
+  )
+  if "%1" == "release" (
+    set build_config=release
+    set boost_build_variant=release
+    set rime_build_variant=release
+  )
+  if "%1" == "rebuild" set build_rebuild=1
+  if "%1" == "boost" set build_boost=1
+  if "%1" == "data" set build_data=1
+  if "%1" == "opencc" set build_opencc=1
+  if "%1" == "rime" set build_rime=1
+  if "%1" == "librime" set build_rime=1
+  if "%1" == "weasel" set build_weasel=1
+  if "%1" == "installer" set build_installer=1
+  if "%1" == "arm64" set build_arm64=1
+  if "%1" == "clean" set build_clean=1
+  if "%1" == "commands" set build_commands=1
+  if "%1" == "all" (
+    set build_boost=1
+    set build_data=1
+    set build_opencc=1
+    set build_rime=1
+    set build_weasel=1
+    set build_installer=1
+    set build_arm64=1
+  )
+  shift
+  goto parse_cmdline_options
+:end_parsing_cmdline_options
+
+if %build_weasel% == 0 (
+if %build_boost% == 0 (
+if %build_data% == 0 (
+if %build_opencc% == 0 (
+if %build_rime% == 0 (
+  set build_weasel=1
+)))))
+rem 
+rem quit WeaselServer.exe before building
+cd /d %WEASEL_ROOT%
+if exist output\weaselserver.exe (
+  output\weaselserver.exe /q
+)
+
+rem build booost
+if %build_boost% == 1 (
+  call build.bat boost
+  if errorlevel 1 exit /b 1
+  cd /d %WEASEL_ROOT%
+  exit /b
+)
+if %build_rime% == 1 (
+  call build.bat rime
+  if errorlevel 1 exit /b 1
+  cd /d %WEASEL_ROOT%
+  exit /b
+)
+if %build_data% == 1 (
+  call build.bat data
+  if errorlevel 1 exit /b 1
+  cd /d %WEASEL_ROOT%
+  exit /b
+)
+if %build_opencc% == 1 (
+  call build.bat opencc
+  if errorlevel 1 exit /b 1
+  cd /d %WEASEL_ROOT%
+  exit /b
+)
+
+if %build_commands% == 1 (
+  xmake project -k compile_commands -m %build_config%
+  exit /b
+)
+
+rem if to clean
+if %build_clean% == 1 ( goto clean )
+
+if %build_arm64% == 1 (
+  xmake f -a arm64 -m %build_config%
+  if %build_rebuild% == 1 ( xmake clean )
+  xmake
+  if errorlevel 1 goto error
+  xmake f -a arm  -m %build_config%
+  if %build_rebuild% == 1 ( xmake clean )
+  xmake
+  if errorlevel 1 goto error
+)
+xmake f -a x64 -m %build_config%
+if %build_rebuild% == 1 ( xmake clean )
+xmake
+if errorlevel 1 goto error
+xmake f -a x86 -m %build_config%
+if %build_rebuild% == 1 ( xmake clean )
+xmake
+if errorlevel 1 goto error
+
+if %build_arm64% == 1 (
+  pushd arm64x_wrapper
+  call build.bat
+  if errorlevel 1 goto error
+  popd
+
+  copy arm64x_wrapper\weaselARM64X.dll output
+  if errorlevel 1 goto error
+  copy arm64x_wrapper\weaselARM64X.ime output
+  if errorlevel 1 goto error
+)
+if %build_installer% == 1 (
+  "%ProgramFiles(x86)%"\NSIS\Bin\makensis.exe ^
+  /DWEASEL_VERSION=%WEASEL_VERSION% ^
+  /DWEASEL_BUILD=%WEASEL_BUILD% ^
+  /DPRODUCT_VERSION=%PRODUCT_VERSION% ^
+  output\install.nsi
+  if errorlevel 1 goto error
+)
+goto end
+
+:clean
+  if exist build (
+    rmdir /s /q build
+    if errorlevel 1 (
+      echo error cleaning weasel build
+      goto error
+    )
+    goto end
+  )
+
+:error
+  echo error building weasel...
+  exit /b 1
+  
+:end
+  cd %WEASEL_ROOT%
+

--- a/xmake.lua
+++ b/xmake.lua
@@ -1,0 +1,107 @@
+-- 工作区的xmake.lua
+set_project("weasel")
+
+-- 定义全局变量
+set_xmakever("2.9.4")
+set_languages("c++17")
+add_defines("UNICODE", "_UNICODE")
+add_defines("WINDOWS")
+add_defines("MSVC")
+
+add_includedirs("$(projectdir)/include")
+-- 设置Boost库的全局路径
+boost_root = os.getenv("BOOST_ROOT")
+boost_include_path = boost_root
+boost_lib_path = boost_root .. "/stage/lib"
+add_includedirs(boost_include_path)
+add_linkdirs(boost_lib_path)
+add_cxflags("/utf-8 /MP /O2 /Oi /Gm- /EHsc /MT /GS /Gy /fp:precise /Zc:wchar_t /Zc:forScope /Zc:inline /external:W3 /Gd /TP /FC")
+add_ldflags("/TLBID:1 /DYNAMICBASE /NXCOMPAT")
+
+-- 全局ATL lib路径
+local atl_lib_dir = ''
+dpi_manifest = ''
+for include in string.gmatch(os.getenv("include"), "([^;]+)") do
+  if atl_lib_dir=='' and include:match(".*ATLMFC\\include\\?$") then
+    atl_lib_dir = include:replace("include$", "lib")
+    dpi_manifest = include:replace("ATLMFC\\include$", "Include\\Manifest\\PerMonitorHighDPIAware.manifest")
+  end
+  add_includedirs(include)
+end
+
+add_includedirs("$(projectdir)/include/wtl")
+
+if is_arch("x64") then
+  add_linkdirs("$(projectdir)/lib64")
+  add_linkdirs(atl_lib_dir .. "/x64")
+elseif is_arch("x86") then
+  add_linkdirs("$(projectdir)/lib")
+  add_linkdirs(atl_lib_dir .. "/x86")
+elseif is_arch("arm") then
+  add_linkdirs(atl_lib_dir .. "/arm")
+elseif is_arch("arm64") then
+  add_linkdirs(atl_lib_dir .. "/arm64")
+end
+
+add_links("atls", "shell32", "advapi32", "gdi32", "user32", "uuid", "ole32")
+
+includes("WeaselIPC", "WeaselUI", "WeaselTSF", "WeaselIME")
+
+if is_arch("x64") or is_arch("x86") then
+  includes("RimeWithWeasel", "WeaselIPCServer", "WeaselServer", "WeaselDeployer")
+end
+
+if is_arch("x86") then
+  includes("WeaselSetup")
+end
+
+if is_mode("debug") then
+  includes("test/TestWeaselIPC")
+  includes("test/TestResponseParser")
+else
+  add_cxflags("/GL")
+  add_ldflags("/LTCG /INCREMENTAL:NO", {force = true})
+end
+
+rule("subcmd")
+  on_load(function(target)
+    target:add("ldflags", "/SUBSYSTEM:CONSOLE")
+  end)
+rule("subwin")
+  on_load(function(target)
+    target:add("ldflags", "/SUBSYSTEM:WINDOWS")
+  end)
+
+rule("add_rcfiles")
+  on_load(function(target)
+    target:add("files", path.join(target:scriptdir(), "*.rc"),
+      {defines = {"VERSION_MAJOR=" .. os.getenv("VERSION_MAJOR"),
+      "VERSION_MINOR=" .. os.getenv("VERSION_MINOR"),
+      "VERSION_PATCH=" .. os.getenv("VERSION_PATCH"),
+      "FILE_VERSION=" .. os.getenv("FILE_VERSION"),
+      "PRODUCT_VERSION=" .. os.getenv("PRODUCT_VERSION")
+    }})
+  end)
+rule("use_weaselconstants")
+  on_load(function(target)
+    function check_include_weasel_constants_in_dir(dir)
+      local files = os.files(path.join(dir, "**.h"))
+      table.join2(files, os.files(path.join(dir, "**.cpp")))
+      for _, file in ipairs(files) do
+        local content = io.readfile(file)
+        if content:find('#include%s+"WeaselConstants%.h"') or content:find('#include%s+<WeaselConstants%.h>') then
+          return true
+        end
+      end
+      return false
+    end
+    if check_include_weasel_constants_in_dir(target:scriptdir()) then
+      target:add("defines", {
+        "VERSION_MAJOR=" .. os.getenv("VERSION_MAJOR"),
+        "VERSION_MINOR=" .. os.getenv("VERSION_MINOR"),
+        "VERSION_PATCH=" .. os.getenv("VERSION_PATCH"),
+        "FILE_VERSION=" .. os.getenv("FILE_VERSION"),
+        "PRODUCT_VERSION=" .. os.getenv("PRODUCT_VERSION")
+    })
+    end
+  end)


### PR DESCRIPTION
xmake optional with xbuild.bat, xmake **2.9.4** is required 

build.bat compatible parameters:

- `release`, `debug`
- `rebuild`
- `boost`
- `data`
- `opencc`
- `rime`, `librime`
- `weasel`
- `installer`
- `arm64`
- `all`

new parameters:
- `clean`     to  clean build cache 
- `commands`  to generate compile_commands.json 