### PR TITLE
feat: GUID_COMPARTMENT_KEYBOARD_OPENCLOSE actions configurable.

### DIFF
--- a/WeaselSetup/WeaselSetup.cpp
+++ b/WeaselSetup/WeaselSetup.cpp
@@ -161,6 +161,14 @@ static int Run(LPTSTR lpCmdLine) {
                           L"CheckForUpdates", L"0", REG_SZ);
   }
 
+  if (!wcscmp(L"/toggleime", lpCmdLine)) {
+    return SetRegKeyValue(HKEY_CURRENT_USER, L"Software\\Rime\\weasel",
+                          L"ToggleImeOnOpenClose", L"yes", REG_SZ);
+  }
+  if (!wcscmp(L"/toggleascii", lpCmdLine)) {
+    return SetRegKeyValue(HKEY_CURRENT_USER, L"Software\\Rime\\weasel",
+                          L"ToggleImeOnOpenClose", L"no", REG_SZ);
+  }
   if (!wcscmp(L"/testing", lpCmdLine)) {
     return SetRegKeyValue(HKEY_CURRENT_USER, L"Software\\Rime\\weasel",
                           L"UpdateChannel", L"testing", REG_SZ);

--- a/WeaselTSF/Compartment.cpp
+++ b/WeaselTSF/Compartment.cpp
@@ -260,6 +260,8 @@ HRESULT WeaselTSF::_HandleCompartment(REFGUID guidCompartment) {
       _HandleLangBarMenuSelect(_status.ascii_mode
                                    ? ID_WEASELTRAY_ENABLE_ASCII
                                    : ID_WEASELTRAY_DISABLE_ASCII);
+      if (_pEditSessionContext)
+        m_client.ClearComposition();
       _UpdateLanguageBar(_status);
     }
   } else if (IsEqualGUID(guidCompartment,

--- a/WeaselTSF/Compartment.cpp
+++ b/WeaselTSF/Compartment.cpp
@@ -5,6 +5,7 @@
 #include <functional>
 #include "ResponseParser.h"
 #include "CandidateList.h"
+#include "LanguageBar.h"
 
 STDAPI CCompartmentEventSink::QueryInterface(REFIID riid,
                                              _Outptr_ void** ppvObj) {
@@ -242,13 +243,25 @@ void WeaselTSF::_UninitCompartment() {
 
 HRESULT WeaselTSF::_HandleCompartment(REFGUID guidCompartment) {
   if (IsEqualGUID(guidCompartment, GUID_COMPARTMENT_KEYBOARD_OPENCLOSE)) {
-    BOOL isOpen = _IsKeyboardOpen();
-    // clear composition when close keyboard
-    if (!isOpen && _pEditSessionContext) {
-      m_client.ClearComposition();
-      _EndComposition(_pEditSessionContext, true);
+    if (_isToOpenClose) {
+      BOOL isOpen = _IsKeyboardOpen();
+      // clear composition when close keyboard
+      if (!isOpen && _pEditSessionContext) {
+        m_client.ClearComposition();
+        _EndComposition(_pEditSessionContext, true);
+      }
+      _EnableLanguageBar(isOpen);
+      _UpdateLanguageBar(_status);
+    } else {
+      _status.ascii_mode = !_status.ascii_mode;
+      _SetKeyboardOpen(true);
+      if (_pLangBarButton && _pLangBarButton->IsLangBarDisabled())
+        _EnableLanguageBar(true);
+      _HandleLangBarMenuSelect(_status.ascii_mode
+                                   ? ID_WEASELTRAY_ENABLE_ASCII
+                                   : ID_WEASELTRAY_DISABLE_ASCII);
+      _UpdateLanguageBar(_status);
     }
-    _EnableLanguageBar(isOpen);
   } else if (IsEqualGUID(guidCompartment,
                          GUID_COMPARTMENT_KEYBOARD_INPUTMODE_CONVERSION)) {
     BOOL isOpen = _IsKeyboardOpen();

--- a/WeaselTSF/KeyEventSink.cpp
+++ b/WeaselTSF/KeyEventSink.cpp
@@ -9,7 +9,10 @@ static BOOL prevfEaten = FALSE;
 static int keyCountToSimulate = 0;
 
 void WeaselTSF::_ProcessKeyEvent(WPARAM wParam, LPARAM lParam, BOOL* pfEaten) {
-  if (!_IsKeyboardOpen() || _IsKeyboardDisabled()) {
+  if (_isToOpenClose && (!_IsKeyboardOpen() || _IsKeyboardDisabled())) {
+    *pfEaten = FALSE;
+    return;
+  } else if (!_isToOpenClose && _IsKeyboardDisabled()) {
     *pfEaten = FALSE;
     return;
   }

--- a/WeaselTSF/KeyEventSink.cpp
+++ b/WeaselTSF/KeyEventSink.cpp
@@ -9,10 +9,9 @@ static BOOL prevfEaten = FALSE;
 static int keyCountToSimulate = 0;
 
 void WeaselTSF::_ProcessKeyEvent(WPARAM wParam, LPARAM lParam, BOOL* pfEaten) {
-  if (_isToOpenClose && (!_IsKeyboardOpen() || _IsKeyboardDisabled())) {
-    *pfEaten = FALSE;
-    return;
-  } else if (!_isToOpenClose && _IsKeyboardDisabled()) {
+  // when _IsKeyboardDisabled don't eat the key,
+  // when keyboard closable and keyboard closed, don't eat the key
+  if ((_isToOpenClose && !_IsKeyboardOpen()) || _IsKeyboardDisabled()) {
     *pfEaten = FALSE;
     return;
   }

--- a/WeaselTSF/LanguageBar.h
+++ b/WeaselTSF/LanguageBar.h
@@ -30,6 +30,7 @@ class CLangBarItemButton : public ITfLangBarItemButton, public ITfSource {
   /* ITfSource */
   STDMETHODIMP AdviseSink(REFIID riid, IUnknown* punk, DWORD* pdwCookie);
   STDMETHODIMP UnadviseSink(DWORD dwCookie);
+  BOOL IsLangBarDisabled() { return (_status & TF_LBI_STATUS_DISABLED); }
 
   void UpdateWeaselStatus(weasel::Status stat);
   void SetLangbarStatus(DWORD dwStatus, BOOL fSet);

--- a/WeaselTSF/WeaselTSF.cpp
+++ b/WeaselTSF/WeaselTSF.cpp
@@ -171,6 +171,10 @@ ExitError:
 }
 
 STDMETHODIMP WeaselTSF::OnSetThreadFocus() {
+  std::wstring _ToggleImeOnOpenClose{};
+  RegGetStringValue(HKEY_CURRENT_USER, L"Software\\Rime\\weasel",
+                    L"ToggleImeOnOpenClose", _ToggleImeOnOpenClose);
+  _isToOpenClose = (_ToggleImeOnOpenClose == L"yes");
   if (m_client.Echo()) {
     m_client.ProcessKeyEvent(0);
     weasel::ResponseParser parser(NULL, NULL, &_status, NULL, &_cand->style());

--- a/WeaselTSF/WeaselTSF.h
+++ b/WeaselTSF/WeaselTSF.h
@@ -232,4 +232,5 @@ class WeaselTSF : public ITfTextInputProcessorEx,
   TfGuidAtom _gaDisplayAttributeInput;
   BOOL _async_edit = false;
   BOOL _committed = false;
+  BOOL _isToOpenClose = false;
 };


### PR DESCRIPTION
- WeaselTSF default toggle ascii_mode on keyboard open/close messages(esp., Ctrl+Space), if `HKEY_CURRENT_USER\SOFTWARE\Rime\Weasel\ToggleImeOnOpenClose` is not set `yes`
- WeaselSetup parameters, `/toggleime` to enable toggle ime on keyboard open/close message, `/toggleascii` to toggle ascii_mode when those messages come.


fixed: #1343 

possible issues:

#997 might be reopen