### PR TITLE
fix: silent installation script typo

### DIFF
--- a/output/install.nsi
+++ b/output/install.nsi
@@ -304,11 +304,7 @@ program_files:
   ; run as user...
   IfSilent +2
     ExecWait "$INSTDIR\WeaselDeployer.exe /install"
-    Goto deploy_done
-
-  ExecWait "$INSTDIR\WeaselDeployer.exe /deploy"
-  deploy_done:
-  ; ...
+    ExecWait "$INSTDIR\WeaselDeployer.exe /deploy"
 
   ; don't redirect on 64 bit system for auto run setting
   ${If} ${IsNativeARM64}


### PR DESCRIPTION
+2: 跳过当前指令和下一条指令

fixes: https://github.com/rime/weasel/commit/8e6b477ea6daec22606f7d42fd4faf67d13a2f65