### PR TITLE
Set inline_preedit to true by default

### DIFF
--- a/output/data/weasel.yaml
+++ b/output/data/weasel.yaml
@@ -1,7 +1,7 @@
 # Weasel settings
 # encoding: utf-8
 
-config_version: "0.22"
+config_version: "0.23"
 
 app_options:
   cmd.exe:
@@ -31,7 +31,7 @@ style:
   click_to_capture: false
   horizontal: false
   fullscreen: false
-  inline_preedit: false
+  inline_preedit: true
   preedit_type: composition
   display_tray_icon: false
   label_format: "%s."


### PR DESCRIPTION
1. 当该选项默认为 false 时，会造成大量应用无法输入或者语法异称
2. 目前设置为 true 没有以上这么多的问题
3. 大部分其他输入法（微信、微软等）包括 Squirrel、ibus-rime 都默认为 true

简单搜索，相关 issue 和影响的应用（无法输入或者功能异常）：

#1326 Evernote 语法功能异常
https://github.com/iDvel/rime-ice/issues/1043 Notion 语法功能异常
~~https://github.com/rime/weasel/issues/1313 Baidu 网页无法输入~~（修复）
https://github.com/rime/weasel/issues/1231 Obsidian 语法功能异常
https://github.com/rime/weasel/issues/1144 Firefox 系全部浏览器的设置面板无法输入
https://github.com/rime/weasel/issues/1106 jetbrains 网页输入异常
https://github.com/rime/weasel/issues/1097 TextMate 插件异常（部分影响）
https://github.com/rime/weasel/issues/1050 Acrobat 导航面板（存疑）
https://github.com/rime/home/discussions/1711 LibreOffice 搜索栏
https://github.com/rime/weasel/issues/1416 千牛工作台
https://github.com/rime/weasel/issues/1407 Discord 频道名称输入栏

部分议题已经关闭，但问题并未解决，考虑到当前无法分网页设置 inline_preedit 状态，更好的解决办法是默认设置为 true