### PR TITLE
fix: avoid input issues in some apps

### DIFF
--- a/WeaselTSF/Composition.cpp
+++ b/WeaselTSF/Composition.cpp
@@ -51,9 +51,9 @@ STDAPI CStartCompositionEditSession::DoEditSession(TfEditCookie ec) {
      * here. The workaround is only needed when inline preedit is not enabled.
      *   See https://github.com/rime/weasel/pull/883#issuecomment-1567625762
      */
-    if (!_inlinePreeditEnabled) {
-      pRangeComposition->SetText(ec, TF_ST_CORRECTION, L" ", 1);
-    }
+    // if (!_inlinePreeditEnabled) {
+    //   pRangeComposition->SetText(ec, TF_ST_CORRECTION, L" ", 1);
+    // }
 
     /* set selection */
     TF_SELECTION tfSelection;

--- a/output/data/weasel.yaml
+++ b/output/data/weasel.yaml
@@ -8,8 +8,6 @@ app_options:
     ascii_mode: true
   conhost.exe:
     ascii_mode: true
-  firefox.exe:
-    inline_preedit: true # workaround for #946
 
 show_notifications: true
 # how long a period notifications shows


### PR DESCRIPTION
注释掉了Composition.cpp中的pRangeComposition->SetText(ec, TF_ST_CORRECTION, L" ", 1); 
https://github.com/rime/weasel/blob/0ef3154e489eed1176e9ca3a2e5f244fc0c1cf0f/WeaselTSF/Composition.cpp#L55
可避免Firefox系浏览器部分情况无法输入问题 #1144 
可能也能解决 #1406 所提到的部分问题