### PR TITLE
fix: candidate ui can't be drawn correctly after GPU reset

### DIFF
--- a/WeaselUI/WeaselPanel.cpp
+++ b/WeaselUI/WeaselPanel.cpp
@@ -179,10 +179,8 @@ void WeaselPanel::_InitFontRes(bool forced) {
   // if style changed, or dpi changed, or pDWR NULL, re-initialize directwrite
   // resources
   if (forced || (pDWR == NULL) || (m_ostyle != m_style) || (dpiX != dpi)) {
-    if (pDWR)
-      pDWR->InitResources(m_style, dpiX);
-    else
-      pDWR = std::make_shared<DirectWriteResources>(m_style, dpiX);
+    pDWR.reset();
+    pDWR = std::make_shared<DirectWriteResources>(m_style, dpiX);
     pDWR->pRenderTarget->SetTextAntialiasMode(
         (D2D1_TEXT_ANTIALIAS_MODE)m_style.antialias_mode);
   }
@@ -1023,7 +1021,10 @@ void WeaselPanel::DoPaint(CDCHandle dc) {
     // draw candidates string
     if (m_candidateCount)
       drawn |= _DrawCandidates(memDC);
-    pDWR->pRenderTarget->EndDraw();
+    if (FAILED(pDWR->pRenderTarget->EndDraw())) {
+      _InitFontRes(true);
+      Refresh();
+    }
     // end texts drawing
 
     // status icon (I guess Metro IME stole my idea :)

--- a/include/WeaselUI.h
+++ b/include/WeaselUI.h
@@ -144,7 +144,8 @@ class DirectWriteResources {
                                   D2D1_DRAW_TEXT_OPTIONS_ENABLE_COLOR_FONT);
   }
   HRESULT CreateBrush(const D2D1_COLOR_F& color) {
-    return pRenderTarget->CreateSolidColorBrush(color, pBrush.GetAddressOf());
+    return pRenderTarget->CreateSolidColorBrush(
+        color, pBrush.ReleaseAndGetAddressOf());
   }
   void ResetLayout() { pTextLayout.Reset(); }
   void SetBrushColor(const D2D1_COLOR_F& color) { pBrush->SetColor(color); }


### PR DESCRIPTION
after GPU reset ( situation of driver reinstalling, wakeup ETC.  ), the render target object will be invalid.

reset direct2d resources if `EndDraw()` failed, then refresh the ui.

Tested by powershell script( run as admin)

```powershell
# 在管理员权限下运行，禁用gpu然后重新启用
# 未修复前可触发小狼毫候选栏空白的bug
Set-ExecutionPolicy RemoteSigned -Scope Process
# 获取显卡设备
$gpu = Get-PnpDevice -Class Display | Where-Object { $_.Status -eq 'OK' }
if ($gpu) {
    # 停用显卡设备
    Disable-PnpDevice -InstanceId $gpu.InstanceId -Confirm:$false
    # 等待
    Start-Sleep -Seconds 2
    # 启用显卡设备
    Enable-PnpDevice -InstanceId $gpu.InstanceId -Confirm:$false
    Write-Host "显卡驱动已成功重新加载。"
} else {
    Write-Host "未找到有效的显卡设备。"
}

```
