### PR TITLE
feat: 添加 `style/comment_on_top`

### DIFF
--- a/RimeWithWeasel/RimeWithWeasel.cpp
+++ b/RimeWithWeasel/RimeWithWeasel.cpp
@@ -1224,6 +1224,8 @@ static void _UpdateUIStyle(RimeConfig* config, UI* ui, bool initialize) {
                true, false);
   _RimeGetBool(config, "style/vertical_auto_reverse", initialize,
                style.vertical_auto_reverse, true, false);
+  _RimeGetBool(config, "style/comment_on_top", initialize, style.comment_on_top,
+               true, false);
   const std::map<std::string, UIStyle::PreeditType> _preeditMap = {
       {std::string("composition"), UIStyle::COMPOSITION},
       {std::string("preview"), UIStyle::PREVIEW},

--- a/WeaselUI/HorizontalLayout.h
+++ b/WeaselUI/HorizontalLayout.h
@@ -11,5 +11,28 @@ class HorizontalLayout : public StandardLayout {
                    PDWR pDWR)
       : StandardLayout(style, context, status, pDWR) {}
   virtual void DoLayout(CDCHandle dc, PDWR pDWR = NULL);
+
+ private:
+  void LayoutWithCommentOnRight(int& w,
+                                int base_offset,
+                                weasel::PDWR& pDWR,
+                                CSize& size,
+                                int& height,
+                                int& row_cnt,
+                                int& max_width_of_rows,
+                                int height_of_rows[100],
+                                int row_of_candidate[100],
+                                int mintop_of_rows[100]);
+
+  void LayoutWithCommentOnTop(int& w,
+                              int base_offset,
+                              weasel::PDWR& pDWR,
+                              CSize& size,
+                              int& height,
+                              int& row_cnt,
+                              int& max_width_of_rows,
+                              int height_of_rows[100],
+                              int row_of_candidate[100],
+                              int mintop_of_rows[100]);
 };
 };  // namespace weasel

--- a/include/WeaselIPCData.h
+++ b/include/WeaselIPCData.h
@@ -264,6 +264,7 @@ struct UIStyle {
   int shadow_offset_x;
   int shadow_offset_y;
   bool vertical_auto_reverse;
+  bool comment_on_top;
   // color scheme
   int text_color;
   int candidate_text_color;
@@ -337,6 +338,7 @@ struct UIStyle {
         shadow_offset_x(0),
         shadow_offset_y(0),
         vertical_auto_reverse(false),
+        comment_on_top(false),
         text_color(0),
         candidate_text_color(0),
         candidate_back_color(0),
@@ -399,6 +401,7 @@ struct UIStyle {
         shadow_offset_x != st.shadow_offset_x ||
         shadow_offset_y != st.shadow_offset_y ||
         vertical_auto_reverse != st.vertical_auto_reverse ||
+        comment_on_top != st.comment_on_top ||
         baseline != st.baseline || linespacing != st.linespacing ||
         text_color != st.text_color ||
         candidate_text_color != st.candidate_text_color ||
@@ -473,6 +476,7 @@ void serialize(Archive& ar, weasel::UIStyle& s, const unsigned int version) {
   ar & s.shadow_offset_x;
   ar & s.shadow_offset_y;
   ar & s.vertical_auto_reverse;
+  ar & s.comment_on_top;
   // color scheme
   ar & s.text_color;
   ar & s.candidate_text_color;

--- a/output/data/weasel.yaml
+++ b/output/data/weasel.yaml
@@ -42,6 +42,7 @@ style:
   vertical_text: false
   vertical_text_left_to_right: false
   vertical_text_with_wrap: false
+  comment_on_top: false
   layout:
     align_type: center
     max_width: 0	#set 0 to disable max width


### PR DESCRIPTION
feat: 添加 `style/comment_on_top`，使得在水平布局时，拼音等注释可以显示在候选字之上。

效果如下：

![图片](https://github.com/user-attachments/assets/cfa451b0-cb43-40fa-b181-0a83ee3d18dc)

![图片](https://github.com/user-attachments/assets/a6fd57fc-5606-4b1b-88ca-c5e41024f7f2)

![图片](https://github.com/user-attachments/assets/87984367-80be-4e27-b2eb-b12e7edae57b)
