### PR TITLE
fix(WeaselUI): highlight back is not drawn correctly when fullscreen layout set

### DIFF
--- a/WeaselUI/FullScreenLayout.cpp
+++ b/WeaselUI/FullScreenLayout.cpp
@@ -61,6 +61,10 @@ void weasel::FullScreenLayout::DoLayout(CDCHandle dc, PDWR pDWR) {
   _prePageRect.OffsetRect(offsetx, offsety);
   _nextPageRect = m_layout->GetNextpageRect();
   _nextPageRect.OffsetRect(offsetx, offsety);
+  _range = m_layout->GetPreeditRange();
+  _beforesz = m_layout->GetBeforeSize();
+  _hilitedsz = m_layout->GetHilitedSize();
+  _aftersz = m_layout->GetAfterSize();
 
   for (auto i = 0, n = (int)_context.cinfo.candies.size();
        i < n && i < MAX_CANDIDATES_COUNT; ++i) {


### PR DESCRIPTION
before
![image](https://github.com/user-attachments/assets/d1d51bdc-8525-4c0c-981f-a01978efc166)
after
![无标题](https://github.com/user-attachments/assets/c94a9dad-7726-4f5e-ae31-62d60d0a4f9d)
