### PR TITLE
build: set /utf-8 for source compilation

### DIFF
--- a/weasel.props.template
+++ b/weasel.props.template
@@ -22,6 +22,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <PreprocessorDefinitions>$(PreprocessorDefinitions);VERSION_MAJOR=$(VERSION_MAJOR);VERSION_MINOR=$(VERSION_MINOR);VERSION_PATCH=$(VERSION_PATCH);</PreprocessorDefinitions>
+      <AdditionalOptions>/utf-8</AdditionalOptions>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>$(PreprocessorDefinitions);VERSION_MAJOR=$(VERSION_MAJOR);VERSION_MINOR=$(VERSION_MINOR);VERSION_PATCH=$(VERSION_PATCH);PRODUCT_VERSION=$(PRODUCT_VERSION);FILE_VERSION=$(FILE_VERSION);</PreprocessorDefinitions>


### PR DESCRIPTION
set `/utf-8` option for all msvc projects, fix charset warning when compiling