### PR TITLE
fix(CandidateList): not displaying in some applications

### DIFF
--- a/WeaselUI/WeaselPanel.cpp
+++ b/WeaselUI/WeaselPanel.cpp
@@ -1066,6 +1066,15 @@ void WeaselPanel::DoPaint(CDCHandle dc) {
   ::DeleteObject(memBitmap);
 }
 
+// 由于某些软件并不依赖 WM_PAINT 消息来重绘，在消息循环中直接忽略掉了 WM_PAINT 消息，
+// 导致 DoPaint() 永远不会被调用，这里手动调用 DoPaint() 强制重绘
+void WeaselPanel::RedrawWindow()
+{
+  HDC hdc = GetDC();
+  DoPaint(hdc);
+  ReleaseDC(hdc);
+}
+
 void WeaselPanel::_LayerUpdate(const CRect& rc, CDCHandle dc) {
   HDC ScreenDC = ::GetDC(NULL);
   CRect rect;

--- a/WeaselUI/WeaselPanel.cpp
+++ b/WeaselUI/WeaselPanel.cpp
@@ -1066,10 +1066,9 @@ void WeaselPanel::DoPaint(CDCHandle dc) {
   ::DeleteObject(memBitmap);
 }
 
-// 由于某些软件并不依赖 WM_PAINT 消息来重绘，在消息循环中直接忽略掉了 WM_PAINT 消息，
-// 导致 DoPaint() 永远不会被调用，这里手动调用 DoPaint() 强制重绘
-void WeaselPanel::RedrawWindow()
-{
+// 由于某些软件并不依赖 WM_PAINT 消息来重绘，在消息循环中直接忽略掉了 WM_PAINT
+// 消息， 导致 DoPaint() 永远不会被调用，这里手动调用 DoPaint() 强制重绘
+void WeaselPanel::RedrawWindow() {
   HDC hdc = GetDC();
   DoPaint(hdc);
   ReleaseDC(hdc);

--- a/WeaselUI/WeaselPanel.h
+++ b/WeaselUI/WeaselPanel.h
@@ -64,6 +64,7 @@ class WeaselPanel
   void Refresh();
   void DoPaint(CDCHandle dc);
   bool GetIsReposition() { return m_istorepos; }
+  void RedrawWindow();
 
   static VOID CALLBACK OnTimer(_In_ HWND hwnd,
                                _In_ UINT uMsg,


### PR DESCRIPTION
fix #1445
fix #1464

感谢 @nicangtianws 提供了一个轻巧且稳定可复现的软件 SimpleStickyNotes。

问题很简单，某些软件并不依赖 WM_PAINT 消息来重绘，甚至直接在消息循环中吃掉了 WM_PAINT 消息，候选框重绘又依赖 WM_PAINT 消息，所以候选框就显示不出来。

解决办法就是手动重绘，不依赖 WM_PAINT 消息。