### PR TITLE
fix(tsf): ime status

### DIFF
--- a/WeaselTSF/Compartment.cpp
+++ b/WeaselTSF/Compartment.cpp
@@ -253,8 +253,7 @@ HRESULT WeaselTSF::_HandleCompartment(REFGUID guidCompartment) {
       _EnableLanguageBar(isOpen);
       _UpdateLanguageBar(_status);
     } else {
-      _status.ascii_mode = !_status.ascii_mode;
-      _SetKeyboardOpen(true);
+      _status.ascii_mode = !_IsKeyboardOpen();
       if (_pLangBarButton && _pLangBarButton->IsLangBarDisabled())
         _EnableLanguageBar(true);
       _HandleLangBarMenuSelect(_status.ascii_mode

--- a/WeaselTSF/LanguageBar.cpp
+++ b/WeaselTSF/LanguageBar.cpp
@@ -416,7 +416,8 @@ void WeaselTSF::_UpdateLanguageBar(weasel::Status stat) {
   else
     flags &= (~TF_CONVERSIONMODE_FULLSHAPE);
   _SetCompartmentDWORD(flags, GUID_COMPARTMENT_KEYBOARD_INPUTMODE_CONVERSION);
-
+  if (!_isToOpenClose && _IsKeyboardOpen() != (!stat.ascii_mode))
+    _SetKeyboardOpen(!stat.ascii_mode);
   _pLangBarButton->UpdateWeaselStatus(stat);
 }
 

--- a/WeaselTSF/LanguageBar.cpp
+++ b/WeaselTSF/LanguageBar.cpp
@@ -416,8 +416,11 @@ void WeaselTSF::_UpdateLanguageBar(weasel::Status stat) {
   else
     flags &= (~TF_CONVERSIONMODE_FULLSHAPE);
   _SetCompartmentDWORD(flags, GUID_COMPARTMENT_KEYBOARD_INPUTMODE_CONVERSION);
-  if (!_isToOpenClose && _IsKeyboardOpen() != (!stat.ascii_mode))
-    _SetKeyboardOpen(!stat.ascii_mode);
+  if (!_isToOpenClose) {
+    BOOL open = !stat.ascii_mode;
+    if (_IsKeyboardOpen() != open)
+      _SetKeyboardOpen(open);
+  }
   _pLangBarButton->UpdateWeaselStatus(stat);
 }
 


### PR DESCRIPTION
fix #1486

现在能正确响应 `ImmSetOpenStatus` 和 `ImmSetConversionStatus`，也能正确支持 ImTip，但是依然发现以下问题：

1. WeaselServer.exe 管理下的托盘图标和悬浮状态图标更新有问题，看了眼 RimeWithWeasel 的实现。。呃，我放弃了。。耦合太强了。
2. 对于 keyboard open，微软拼音是在获得焦点时无脑 open 并切换为中文输入，但是这样就与 `ImmSetConversionStatus` 冲突，调用输入法的程序无法通过 api 切换为英文输入，想了想还是不跟了，影响太大。