### PR TITLE
chore: make clang-format.ps1 worked in linux/Mac OS[skip ci]

### DIFF
--- a/clang-format.ps1
+++ b/clang-format.ps1
@@ -21,7 +21,7 @@ $filesToProcess = @()
 
 $WEASEL_SOURCE_PATH | ForEach-Object {
   $filesToProcess += Get-ChildItem -Path $_ -Recurse -Include *.cpp, *.h |
-  Where-Object { $_.FullName -notmatch "include\\wtl\\" -and -not (ShouldExclude $_.FullName) } |
+  Where-Object { $_.FullName -notmatch "include[\\/]wtl[\\/]" -and -not (ShouldExclude $_.FullName) } |
   ForEach-Object { $_.FullName }
 }
 


### PR DESCRIPTION
tested in Ubuntu 22.04 (WSL) with Powershell 7.4.7