### PR TITLE
ci: run update rime/home appcast on published or prereleased

### DIFF
--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -112,9 +112,3 @@ jobs:
             ./output/archives/weasel*.exe
             ./output/archives/debug_symbols.7z
           body_path: ${{ github.workspace }}/RELEASE_CHANGELOG.md
-        
-      - name: Update testing Appcast
-        if: ${{ github.repository == 'rime/weasel' }}
-        run: gh workflow run gh-pages.yml -R rime/home --ref master
-        env:
-          GH_TOKEN: ${{ secrets.ACTIONS_DEPLOY_KEY }}

--- a/.github/workflows/update-appcast.yml
+++ b/.github/workflows/update-appcast.yml
@@ -1,0 +1,16 @@
+name: Update Appcast
+on:
+  release:
+    types: [published, prereleased]
+jobs:
+
+  update_appcast:
+
+    runs-on: windows-2019
+
+    steps:
+      - name: Update Appcast
+        if: ${{ github.repository == 'rime/weasel' }}
+        run: gh workflow run gh-pages.yml -R rime/home --ref master
+        env:
+          GH_TOKEN: ${{ secrets.ACTIONS_DEPLOY_KEY }}


### PR DESCRIPTION
don't update appcast on rime/home in release-ci.yaml workflow, but on published (draft release published) or prereleased (nightly)