### PR TITLE
feat(tsf): hide IME mode icon

### DIFF
--- a/WeaselSetup/WeaselSetup.cpp
+++ b/WeaselSetup/WeaselSetup.cpp
@@ -186,6 +186,16 @@ static int Run(LPTSTR lpCmdLine) {
     return SetRegKeyValue(HKEY_CURRENT_USER, L"Software\\Rime\\weasel",
                           L"ToggleImeOnOpenClose", L"no", REG_SZ);
   }
+
+  if (!wcscmp(L"/hidemodeicon", lpCmdLine)) {
+    return SetRegKeyValue(HKEY_CURRENT_USER, L"Software\\Rime\\weasel",
+                          L"HideImeModeIcon", L"yes", REG_SZ);
+  }
+  if (!wcscmp(L"/showmodeicon", lpCmdLine)) {
+    return SetRegKeyValue(HKEY_CURRENT_USER, L"Software\\Rime\\weasel",
+                          L"HideImeModeIcon", L"no", REG_SZ);
+  }
+
   if (!wcscmp(L"/testing", lpCmdLine)) {
     return SetRegKeyValue(HKEY_CURRENT_USER, L"Software\\Rime\\weasel",
                           L"UpdateChannel", L"testing", REG_SZ);

--- a/WeaselTSF/LanguageBar.cpp
+++ b/WeaselTSF/LanguageBar.cpp
@@ -374,8 +374,12 @@ BOOL WeaselTSF::_InitLanguageBar() {
   if (_pThreadMgr->QueryInterface(&pLangBarItemMgr) != S_OK)
     return FALSE;
 
-  if ((_pLangBarButton = new CLangBarItemButton(this, GUID_LBI_INPUTMODE,
-                                                _cand->style())) == NULL)
+  std::wstring hideIcon{};
+  RegGetStringValue(HKEY_CURRENT_USER, L"Software\\Rime\\weasel",
+                    L"HideImeModeIcon", hideIcon);
+  GUID langBarGuid = (hideIcon == L"yes") ? GUID_NULL : GUID_LBI_INPUTMODE;
+  if ((_pLangBarButton =
+           new CLangBarItemButton(this, langBarGuid, _cand->style())) == NULL)
     return FALSE;
 
   if (pLangBarItemMgr->AddItem(_pLangBarButton) != S_OK) {


### PR DESCRIPTION
相关 issue：

* https://github.com/rime/weasel/issues/1432
* https://github.com/rime/weasel/issues/961
* https://github.com/rime/weasel/issues/818
* https://github.com/rime/weasel/issues/357

微软文档：
https://learn.microsoft.com/en-us/windows/apps/design/input/input-method-editor-requirements#ime-mode-icon