### PR TITLE
fix(installer): avoid files are deleted on system reboot when weasel is reinstalled in the same WeaselRoot

### DIFF
--- a/output/install.nsi
+++ b/output/install.nsi
@@ -161,7 +161,34 @@ uninst:
   CopyFiles $R1\data\*.* $TEMP\weasel-backup
 
 call_uninstaller:
-  ExecWait '$R0 /S'
+  ExecWait '"$R1\WeaselServer.exe" /quit'
+  ExecWait '"$R1\WeaselSetup.exe" /u'
+  ; Remove registry keys
+  DeleteRegKey HKLM SOFTWARE\Rime
+  DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Weasel"
+  ; don't redirect on 64 bit system for auto run setting
+  ${If} ${IsNativeARM64}
+    SetRegView 64
+  ${ElseIf} ${IsNativeAMD64}
+    SetRegView 64
+  ${Endif}
+  DeleteRegValue HKLM "Software\Microsoft\Windows\CurrentVersion\Run" "WeaselServer"
+  ; recover back to 32bit view
+  SetRegView 32
+  ; Remove files and uninstaller
+  Delete  "$R1\data\opencc\*.*"
+  Delete  "$R1\data\preview\*.*"
+  Delete  "$R1\data\*.*"
+  Delete  "$R1\*.*"
+  RMDir   "$R1\data\opencc"
+  RMDir   "$R1\data\preview"
+  RMDir   "$R1\data"
+  RMDir   "$R1"
+  SetShellVarContext all
+  Delete  "$SMPROGRAMS\$(DISPLAYNAME)\*.*"
+  RMDir  "$SMPROGRAMS\$(DISPLAYNAME)"
+  ; Prompt reboot
+  SetRebootFlag true
   Sleep 800
 
 done:

--- a/output/install.nsi
+++ b/output/install.nsi
@@ -378,17 +378,17 @@ Section "Uninstall"
 
   ; Remove files and uninstaller
   SetOutPath $TEMP
-  Delete /REBOOTOK "$INSTDIR\data\opencc\*.*"
-  Delete /REBOOTOK "$INSTDIR\data\preview\*.*"
-  Delete /REBOOTOK "$INSTDIR\data\*.*"
-  Delete /REBOOTOK "$INSTDIR\*.*"
-  RMDir /REBOOTOK "$INSTDIR\data\opencc"
-  RMDir /REBOOTOK "$INSTDIR\data\preview"
-  RMDir /REBOOTOK "$INSTDIR\data"
-  RMDir /REBOOTOK "$INSTDIR"
+  Delete  "$INSTDIR\data\opencc\*.*"
+  Delete  "$INSTDIR\data\preview\*.*"
+  Delete  "$INSTDIR\data\*.*"
+  Delete  "$INSTDIR\*.*"
+  RMDir  "$INSTDIR\data\opencc"
+  RMDir  "$INSTDIR\data\preview"
+  RMDir  "$INSTDIR\data"
+  RMDir  "$INSTDIR"
   SetShellVarContext all
-  Delete /REBOOTOK "$SMPROGRAMS\$(DISPLAYNAME)\*.*"
-  RMDir /REBOOTOK "$SMPROGRAMS\$(DISPLAYNAME)"
+  Delete  "$SMPROGRAMS\$(DISPLAYNAME)\*.*"
+  RMDir  "$SMPROGRAMS\$(DISPLAYNAME)"
 
   ; Prompt reboot
   SetRebootFlag true


### PR DESCRIPTION
NSIS about `/REBOOTOK`
https://nsis.sourceforge.io/Reference/Delete#:~:text=If%20%2FREBOOTOK%20is%20specified%20and%20the%20file%20cannot,a%20reboot%2C%20the%20reboot%20flag%20will%20be%20set.


fix: #1514 
fix: #1496