### PR TITLE
fix(trayicon): explorer.exe hangs

### DIFF
--- a/RimeWithWeasel/RimeWithWeasel.cpp
+++ b/RimeWithWeasel/RimeWithWeasel.cpp
@@ -116,7 +116,7 @@ void _RefreshTrayIcon(const RimeSessionId session_id,
   static char app_name[50];
   rime_api->get_property(session_id, "client_app", app_name,
                          sizeof(app_name) - 1);
-  if (u8tow(app_name) == std::wstring(L"explorer.exe"))
+  if (u8tow(app_name) == std::wstring(L"explorer.exe") || !app_name[0])
     boost::thread th([=]() {
       ::Sleep(100);
       if (_UpdateUICallback)


### PR DESCRIPTION
应该可以修复托盘图标卡死 explorer.exe，其实是卡住 7 秒。

我这里测试是不卡了，还需要更多测试。