### PR TITLE
Pr1522

### DIFF
--- a/RimeWithWeasel/RimeWithWeasel.cpp
+++ b/RimeWithWeasel/RimeWithWeasel.cpp
@@ -113,10 +113,10 @@ void _LoadAppOptions(RimeConfig* config, AppOptionsByAppName& app_options);
 void _RefreshTrayIcon(const RimeSessionId session_id,
                       const std::function<void()> _UpdateUICallback) {
   // Dangerous, don't touch
-  static char app_name[50];
-  rime_api->get_property(session_id, "client_app", app_name,
-                         sizeof(app_name) - 1);
-  if (u8tow(app_name) == std::wstring(L"explorer.exe") || !app_name[0])
+  static char app_name[256] = {0};
+  auto ret = rime_api->get_property(session_id, "client_app", app_name,
+                                    sizeof(app_name) - 1);
+  if (!ret || u8tow(app_name) == std::wstring(L"explorer.exe"))
     boost::thread th([=]() {
       ::Sleep(100);
       if (_UpdateUICallback)

--- a/RimeWithWeasel/RimeWithWeasel.cpp
+++ b/RimeWithWeasel/RimeWithWeasel.cpp
@@ -116,7 +116,7 @@ void _RefreshTrayIcon(const RimeSessionId session_id,
   static char app_name[50];
   rime_api->get_property(session_id, "client_app", app_name,
                          sizeof(app_name) - 1);
-  if (u8tow(app_name) == std::wstring(L"explorer.exe"))
+  if (u8tow(app_name) == std::wstring(L"explorer.exe") || !app_name[0])
     boost::thread th([=]() {
       ::Sleep(100);
       if (_UpdateUICallback)


### PR DESCRIPTION
fix: explorer.exe hangs, when trayicon  refresh with `client_app` property empty 

close #1522