### PR TITLE
chore: update bump version scripts

### DIFF
--- a/update/bump-version.ps1
+++ b/update/bump-version.ps1
@@ -90,6 +90,13 @@ function update_changelog {
   $fileContent = Get-Content -Path "CHANGELOG.md" -Raw -Encoding UTF8;
   $contentAdd = "<a name=`"$new_tag`"></a>`n" ;
   $contentAdd += "## [$new_tag](https://github.com/rime/weasel/compare/$old_tag...$new_tag)($currentDateTime)`n" ;
+  # if $new_tag.txt exists, add the content to changelog
+  $new_tag_file = "$new_tag.txt";
+  if (Test-Path -Path $new_tag_file) {
+    $new_tag_content = Get-Content -Path $new_tag_file -Raw -Encoding UTF8;
+    $contentAdd += "`n" + $new_tag_content + "`n";
+  }
+
   $contentAdd += $changelog;
   Write-Host "`n" + $contentAdd + "`n"
   $fileContent = $contentAdd + "`n" + $fileContent;

--- a/update/bump-version.sh
+++ b/update/bump-version.sh
@@ -96,6 +96,12 @@ update_changelog() {
   local contentAdd
   contentAdd="<a name=\"$new_tag\"></a>"$'\n'
   contentAdd+="## [$new_tag](https://github.com/rime/weasel/compare/$old_tag...$new_tag)($currentDateTime)"$'\n'
+  # if $new_tag.txt exists, add the content to changelog
+  if [[ -f "$new_tag.txt" ]]; then
+    contentAdd+=$'\n'
+    contentAdd+=$(<"$new_tag.txt")
+    contentAdd+=$'\n'
+  fi
   contentAdd+="$changelog"
   contentAdd=$"$contentAdd"$'\n'
 


### PR DESCRIPTION
prepare txt file of new tag name like 0.16.3.txt, which contains extra changelog information to insert