### PR TITLE
fix(RimeWithWeasel): color parsing for decimal number

### DIFF
--- a/RimeWithWeasel/RimeWithWeasel.cpp
+++ b/RimeWithWeasel/RimeWithWeasel.cpp
@@ -1033,7 +1033,8 @@ static Bool _RimeGetColor(RimeConfig* config,
     if (!rime_api->config_get_int(config, key.c_str(), &tmp)) {
       value = fallback;
       return False;
-    }
+    } else
+      value = tmp;
     make_opaque(value);
   }
   value = ConvertColorToAbgr(value, fmt);
@@ -1377,7 +1378,8 @@ static bool _UpdateUIStyleColor(RimeConfig* config,
     COLOR("label_color", style.label_text_color,
           blend_colors(style.candidate_text_color, style.candidate_back_color));
     COLOR("hilited_label_color", style.hilited_label_text_color,
-          blend_colors(style.candidate_text_color, style.candidate_back_color));
+          blend_colors(style.hilited_candidate_text_color,
+                       style.hilited_candidate_back_color));
     COLOR("comment_text_color", style.comment_text_color,
           style.label_text_color);
     COLOR("hilited_comment_text_color", style.hilited_comment_text_color,


### PR DESCRIPTION
fix(RimeWithWeasel): highlight label color and highlight comment color not correct when it's not defined

fix: #1582 