### PR TITLE
Allow specifying custom appcast URL 允許指定自訂更新渠道

### DIFF
--- a/WeaselServer/WeaselServerApp.h
+++ b/WeaselServer/WeaselServerApp.h
@@ -41,6 +41,9 @@ class WeaselServerApp {
                                  L"UpdateChannel", channel);
     if (!ret && channel == L"testing") {
       feed_url = GetCustomResource("TestingManualUpdateFeedURL", "APPCAST");
+    } else if (!wcsncmp(channel.c_str(), L"http://", wcslen(L"http://")) ||
+               !wcsncmp(channel.c_str(), L"https://", wcslen(L"https://"))) {
+      feed_url = wtou8(channel);
     }
     if (!feed_url.empty()) {
       win_sparkle_set_appcast_url(feed_url.c_str());


### PR DESCRIPTION
為方便用户能一鍵安裝輸入粵語，我們（維護 rime-cantonese 的 CanCLID）從 2021 年開始已經會定期打包包含 rime-cantonese 及其依賴方案的安裝包。

但由於 appcast 頻道 hard code 成 http://rime.github.io/release/weasel/appcast.xml （或 http://rime.github.io/testing/weasel/appcast.xml​ ），現在用户透過 WinSparkle 更新程式時，仍會安裝 https://github.com/rime/weasel/releases 中的版本，導致「程序文件夾」中的方案被覆蓋，方案變化導致許多用户曾經投訴更新後不能正常使用。

此 PR 允許從登錄檔（註冊表）指定更新渠道，這樣就能從 `install.nsi` 指定 URL，不需重新編譯整個程式。