### PR TITLE
[WIP] WeaselSetup: Remove ARM32 installation logic

### DIFF
--- a/WeaselServer/SystemTraySDK.cpp
+++ b/WeaselServer/SystemTraySDK.cpp
@@ -765,7 +765,7 @@ LRESULT CSystemTray::OnTrayNotification(WPARAM wParam, LPARAM lParam) {
   if (!hTargetWnd)
     return 0L;
 
-    // Clicking with right button brings up a context menu
+  // Clicking with right button brings up a context menu
 #if defined(_WIN32_WCE)  //&& _WIN32_WCE < 211
   BOOL bAltPressed =
       ((GetKeyState(VK_MENU) & (1 << (sizeof(SHORT) * 8 - 1))) != 0);

--- a/WeaselServer/WeaselService.cpp
+++ b/WeaselServer/WeaselService.cpp
@@ -66,7 +66,9 @@ void WeaselService::Start(DWORD dwArgc = 0, PWSTR* pszArgv = NULL) {
 
     // Perform service-specific initialization.
     // if (IsWindowsVistaOrGreater())
-    { RegisterApplicationRestart(NULL, 0); }
+    {
+      RegisterApplicationRestart(NULL, 0);
+    }
     boost::thread{[this] { app.Run(); }};
     // Tell SCM that the service is started.
     SetServiceStatus(SERVICE_RUNNING);

--- a/WeaselSetup/imesetup.cpp
+++ b/WeaselSetup/imesetup.cpp
@@ -439,7 +439,9 @@ int register_text_service(const std::wstring& tsf_path,
     params = L" /u " + params;  // unregister
   }
   // if (silent)  // always silent
-  { params = L" /s " + params; }
+  {
+    params = L" /s " + params;
+  }
 
   if (hant) {
     if (!SetEnvironmentVariable(L"TEXTSERVICE_PROFILE", L"hant")) {
@@ -621,4 +623,3 @@ bool has_installed() {
   return (attr != INVALID_FILE_ATTRIBUTES &&
           !(attr & FILE_ATTRIBUTE_DIRECTORY));
 }
-


### PR DESCRIPTION
Since ARM32 support is being dropped (https://github.com/rime/weasel/pull/1730), remove the related logic in WeaselSetup.

Otherwise install will fail complaining about missing ARM32 TSF dlls.