### PR TITLE
Reduce redundant _GetCandidateInfo() calls

### DIFF
--- a/RimeWithWeasel/RimeWithWeasel.cpp
+++ b/RimeWithWeasel/RimeWithWeasel.cpp
@@ -789,6 +789,11 @@ bool RimeWithWeaselHandler::_Respond(WeaselSessionId ipc_id, EatLine eat) {
 
   RIME_STRUCT(RimeContext, ctx);
   if (rime_api->get_context(session_id, &ctx)) {
+    bool has_candidates = ctx.menu.num_candidates > 0;
+    CandidateInfo cinfo;
+    if (has_candidates) {
+      _GetCandidateInfo(cinfo, ctx);
+    }
     if (is_composing) {
       actions.insert("ctx");
       switch (session_status.style.preedit_type) {
@@ -826,8 +831,6 @@ bool RimeWithWeaselHandler::_Respond(WeaselSessionId ipc_id, EatLine eat) {
           }
           break;
         case UIStyle::PREVIEW_ALL:
-          CandidateInfo cinfo;
-          _GetCandidateInfo(cinfo, ctx);
           std::string topush = std::string("ctx.preedit=") +
                                escape_string<char>(ctx.composition.preedit) +
                                "  [";
@@ -867,11 +870,9 @@ bool RimeWithWeaselHandler::_Respond(WeaselSessionId ipc_id, EatLine eat) {
           break;
       }
     }
-    if (ctx.menu.num_candidates) {
-      CandidateInfo cinfo;
+    if (has_candidates) {
       std::wstringstream ss;
       boost::archive::text_woarchive oa(ss);
-      _GetCandidateInfo(cinfo, ctx);
 
       oa << cinfo;
 


### PR DESCRIPTION
Optimize _GetCandidateInfo() calls in _Respond()

This may provide some optimization when PREVIEW_ALL is enabled.