### PR TITLE
allow hide candidate list by rime option _hide_candidate

### DIFF
--- a/RimeWithWeasel/RimeWithWeasel.cpp
+++ b/RimeWithWeasel/RimeWithWeasel.cpp
@@ -1388,6 +1388,8 @@ void RimeWithWeaselHandler::_GetStatus(Status& stat,
     stat.composing = !!status.is_composing;
     stat.disabled = !!status.is_disabled;
     stat.full_shape = !!status.is_full_shape;
+    stat.hide_candidates =
+        !!rime_api->get_option(session_id, "_hide_candidate");
     if (schema_id != m_last_schema_id) {
       session_status.__synced = false;
       m_last_schema_id = schema_id;

--- a/WeaselUI/WeaselPanel.cpp
+++ b/WeaselUI/WeaselPanel.cpp
@@ -149,7 +149,7 @@ void WeaselPanel::Refresh() {
   // 2. inline preedit without candidates
   bool inline_no_candidates =
       (m_style.inline_preedit && m_candidateCount == 0) && !show_tips;
-  hide_candidates = inline_no_candidates ||
+  hide_candidates = m_status.hide_candidates || inline_no_candidates ||
                     (margin_negative && !show_tips && !show_schema_menu);
 
   // only RedrawWindow if no need to hide candidates window, or

--- a/include/WeaselIPCData.h
+++ b/include/WeaselIPCData.h
@@ -153,7 +153,8 @@ struct Status {
         ascii_mode(false),
         composing(false),
         disabled(false),
-        full_shape(false) {}
+        full_shape(false),
+        hide_candidates(false) {}
   void reset() {
     schema_name.clear();
     schema_id.clear();
@@ -161,13 +162,15 @@ struct Status {
     composing = false;
     disabled = false;
     full_shape = false;
+    hide_candidates = false;
     type = SCHEMA;
   }
   bool operator==(const Status status) {
     return (status.schema_name == schema_name &&
             status.schema_id == schema_id && status.ascii_mode == ascii_mode &&
             status.composing == composing && status.disabled == disabled &&
-            status.full_shape == full_shape && status.type == type);
+            status.full_shape == full_shape &&
+            status.hide_candidates == hide_candidates && status.type == type);
   }
   // 輸入方案
   std::wstring schema_name;
@@ -181,6 +184,8 @@ struct Status {
   bool disabled;
   // 全角状态
   bool full_shape;
+  // 是否隐藏候选列表
+  bool hide_candidates;
   // 图标类型, schema/full_shape
   IconType type;
 };


### PR DESCRIPTION
This pull request introduces the ability to control whether the candidate list is displayed through a Rime option (_hide_candidate). This feature was originally implemented in [Trime](https://github.com/osfans/trime).

When the option is enabled, Weasel will skip populating and drawing the candidate list, allowing users or schemas to dynamically hide candidates without relying on theme configuration.

Usage Example
```yaml
#in xxx.schema.yaml or xxx.custom.yaml
switches:
  - name: _hide_candidate
    reset: 1
```

1. When _hide_candidate is 1, the candidate list remains empty and the candidate window stays hidden.
2. Default behavior remains unchanged (candidates are shown unless explicitly hidden).
3. No impact on existing configurations.
4. The _hide_candidate option is optional and off by default.
5. Fully compatible with existing themes and styles.
6. With this option, user can dynamic control candidates list by librime-lua script.

The same feature has been merged into Squirrel via [#1073](https://github.com/rime/squirrel/pull/1073)