### PR TITLE
remove .xmake-cache

### DIFF
--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -153,7 +153,6 @@ jobs:
       - uses: xmake-io/github-action-setup-xmake@v1
         with:
           xmake-version: '2.9.4'
-          actions-cache-folder: '.xmake-cache'
 
       - uses: ilammy/msvc-dev-cmd@v1
         with:


### PR DESCRIPTION
Delete actions-cache-folder: '.xmake-cache' to fix a GitHub workflow Warning: The .xmake-cache files does not exist. This configuration line does not affect the project build regardless of its presence or absence.