### PR TITLE
fix(WeaselTSF): Always update UIElements.

### DIFF
--- a/WeaselTSF/CandidateList.cpp
+++ b/WeaselTSF/CandidateList.cpp
@@ -209,8 +209,7 @@ void CCandidateList::UpdateUI(const Context& ctx, const Status& status) {
   /// if it is owned by active view window
   //_UpdateOwner();
   _ui->Update(ctx, status);
-  if (_pbShow == FALSE)
-    _UpdateUIElement();
+  _UpdateUIElement();
 
   if (status.composing)
     Show(_pbShow);


### PR DESCRIPTION
在非 UILess 模式下也向 TFS 管理器报告 UIElement 更新。这使 TFS 应用始终可以获取候选内容。

这支持 [NVDA](https://github.com/nvaccess/nvda) 等支持 TFS 框架输入法的屏幕阅读器在输入时读出候选。

## 测试：

使用 [InputMethodCandidateReader](https://github.com/chinput/InputMethodCandidateReader) 进行测试。

UILess 模式：
<img width="1426" height="746" alt="UILess 模式" src="https://github.com/user-attachments/assets/282d4b9b-b963-457d-b7c4-190b574c0440" />

非 UILess 模式
<img width="1426" height="746" alt="非 UILess 模式" src="https://github.com/user-attachments/assets/92d50410-3331-4f94-8156-4ea7d936d5b0" />
