### PR TITLE
fix (WeaselUI): Crash when the Weasel Panel creation is re-entried.

### DIFF
--- a/WeaselUI/WeaselUI.cpp
+++ b/WeaselUI/WeaselUI.cpp
@@ -83,23 +83,19 @@ VOID CALLBACK UIImpl::OnTimer(_In_ HWND hwnd,
 }
 
 bool UI::Create(HWND parent) {
-  if (pimpl_) {
-    pimpl_->panel.Create(
-        parent, 0, 0, WS_POPUP,
-        WS_EX_TOOLWINDOW | WS_EX_TOPMOST | WS_EX_NOACTIVATE | WS_EX_TRANSPARENT,
-        0U, 0);
-    return true;
+  if (!pimpl_) {
+    pimpl_ = new UIImpl(*this);
+    if (!pimpl_)
+      return false;
   }
 
-  pimpl_ = new UIImpl(*this);
-  if (!pimpl_)
-    return false;
+  if (pimpl_->panel.IsWindow())
+    return true;
 
-  pimpl_->panel.Create(
-      parent, 0, 0, WS_POPUP,
-      WS_EX_TOOLWINDOW | WS_EX_TOPMOST | WS_EX_NOACTIVATE | WS_EX_TRANSPARENT,
-      0U, 0);
-  return true;
+  return pimpl_->panel.Create(parent, 0, 0, WS_POPUP,
+                              WS_EX_TOOLWINDOW | WS_EX_TOPMOST |
+                                  WS_EX_NOACTIVATE | WS_EX_TRANSPARENT,
+                              0U, 0) != nullptr;
 }
 
 void UI::Destroy(bool full) {


### PR DESCRIPTION
尝试修复如下问题：打开 Thunderbird 的回复窗口后，如果 Thunderbird 安装了 Reply With Header 扩展，那么由于目前疑似 Thunderbird 的问题（我目前开在了 https://bugzilla.mozilla.org/show_bug.cgi?id=2031427 ），在一些条件下 `StartComposition` 调用会返回 `E_FAIL`。然后因为一些未知原因 `UI::Create` 会在未销毁之前就被调用。

在 Debug 下这会造成 Assertion Fail，在 Release 下似乎会造成后续的空指针解引用（具体位置没有特别定位到，因为测的时候没带调试 PDB）带崩整个 Thunderbird。

此 commit 尝试把 `UI::Create` 改成幂等的，目前是复用了一下现有的 Panel，或许也应该考虑一下先销毁再创建新的，如果有必要例如更换 parent 等。但至少不应该出现输入法带崩整个应用程序的情况。