### PR TITLE
feat: configurable Ctrl+Space synthetic key via weasel.yaml::ctrl_space_key

### DIFF
--- a/RimeWithWeasel/RimeWithWeasel.cpp
+++ b/RimeWithWeasel/RimeWithWeasel.cpp
@@ -1,5 +1,6 @@
-﻿#include "stdafx.h"
+#include "stdafx.h"
 #include <logging.h>
+#include <KeyEvent.h>
 #include <RimeWithWeasel.h>
 #include <StringAlgorithm.hpp>
 #include <WeaselConstants.h>
@@ -10,6 +11,7 @@
 #include <array>
 #include <vector>
 #include <regex>
+#include <unordered_map>
 #include <rime_api.h>
 
 #define TRANSPARENT_COLOR 0x00000000
@@ -22,6 +24,20 @@
 typedef enum { COLOR_ABGR = 0, COLOR_ARGB, COLOR_RGBA } ColorFormat;
 
 using namespace weasel;
+
+// 把 weasel.yaml::ctrl_space_key 配置名解析成 ibus keycode。
+// 特殊返回值：0 表示显式禁用；未识别的名字回落为 Shift_L（默认行为）。
+static UINT32 parse_ctrl_space_key(const std::string& name) {
+  static const std::unordered_map<std::string, UINT32> table = {
+      {"Shift_L", ibus::Shift_L},    {"Shift_R", ibus::Shift_R},
+      {"Alt_L", ibus::Alt_L},        {"Alt_R", ibus::Alt_R},
+      {"Eisu_toggle", ibus::Eisu_toggle},
+  };
+  if (name == "disable" || name == "none")
+    return 0;
+  auto it = table.find(name);
+  return it == table.end() ? ibus::Shift_L : it->second;
+}
 
 static RimeApi* rime_api;
 WeaselSessionId _GenerateNewWeaselSessionId(SessionStatusMap sm, DWORD pid) {
@@ -41,7 +57,8 @@ RimeWithWeaselHandler::RimeWithWeaselHandler(UI* ui)
       m_current_dark_mode(false),
       m_global_ascii_mode(false),
       m_show_notifications_time(1200),
-      _UpdateUICallback(NULL) {
+      _UpdateUICallback(NULL),
+      m_ctrl_space_keycode(ibus::Shift_L) {
   m_ui->InServer() = true;
   rime_api = rime_get_api();
   assert(rime_api);
@@ -140,6 +157,14 @@ void RimeWithWeaselHandler::Initialize() {
     if (!rime_api->config_get_int(&config, "show_notifications_time",
                                   &m_show_notifications_time))
       m_show_notifications_time = 1200;
+    {
+      char buf[64] = {0};
+      if (rime_api->config_get_string(&config, "ctrl_space_key", buf,
+                                      sizeof(buf))) {
+        m_ctrl_space_keycode = parse_ctrl_space_key(buf);
+      }
+      // 未配置：保持 ctor 中的默认值 ibus::Shift_L
+    }
     _LoadAppOptions(&config, m_app_options);
     rime_api->config_close(&config);
   }
@@ -897,6 +922,9 @@ bool RimeWithWeaselHandler::_Respond(WeaselSessionId ipc_id, EatLine eat) {
   actions.push_back("config");
   body.append(L"config.inline_preedit=")
       .append(std::to_wstring((int)session_status.style.inline_preedit))
+      .append(L"\n");
+  body.append(L"config.ctrl_space_keycode=")
+      .append(std::to_wstring(m_ctrl_space_keycode))
       .append(L"\n");
 
   // style

--- a/WeaselIPC/Configurator.cpp
+++ b/WeaselIPC/Configurator.cpp
@@ -14,10 +14,13 @@ Configurator::~Configurator() {}
 
 void Configurator::Store(Deserializer::KeyType const& key,
                          std::wstring const& value) {
-  if (!m_pTarget->p_context || key.size() < 2)
+  if (!m_pTarget->p_config || key.size() < 2)
     return;
   bool bool_value = (!value.empty() && value != L"0");
   if (key[1] == L"inline_preedit") {
     m_pTarget->p_config->inline_preedit = bool_value;
+  } else if (key[1] == L"ctrl_space_keycode") {
+    m_pTarget->p_config->ctrl_space_keycode =
+        static_cast<unsigned int>(_wtoi(value.c_str()));
   }
 }

--- a/WeaselTSF/Compartment.cpp
+++ b/WeaselTSF/Compartment.cpp
@@ -302,6 +302,21 @@ HRESULT WeaselTSF::_HandleCompartment(REFGUID guidCompartment) {
       // switch_key set. Without clearing it, the synthesized release
       // wouldn't be "pure" and ascii_composer would ignore it.
       UINT32 keycode = _config.ctrl_space_keycode;
+      bool config_synced = (keycode != 0);
+      if (!config_synced && _EnsureServerConnected()) {
+        // On a cold start, TSF may see the default 0 before the first
+        // response sync arrives. Pull one response here so we can
+        // distinguish "not synced yet" from an explicit disable.
+        m_client.ProcessKeyEvent(0);
+        weasel::ResponseParser parser(NULL, NULL, &_status, &_config, NULL);
+        if (m_client.GetResponseData(std::ref(parser))) {
+          keycode = _config.ctrl_space_keycode;
+          config_synced = true;
+        }
+      }
+      if (!config_synced) {
+        keycode = ibus::Shift_L;
+      }
       if (keycode != 0 && _pEditSessionContext && _EnsureServerConnected()) {
         m_client.ProcessKeyEvent(
             weasel::KeyEvent{ibus::Control_L, ibus::RELEASE_MASK});

--- a/WeaselTSF/Compartment.cpp
+++ b/WeaselTSF/Compartment.cpp
@@ -48,6 +48,36 @@ STDAPI CCompartmentEventSink::OnChange(_In_ REFGUID guidCompartment) {
   return _callback(guidCompartment);
 }
 
+// 对应合成 keycode 的 modifier mask（press 事件使用）。
+static UINT32 press_mask_for(UINT32 keycode) {
+  switch (keycode) {
+    case ibus::Shift_L:
+    case ibus::Shift_R:
+      return ibus::SHIFT_MASK;
+    case ibus::Alt_L:
+    case ibus::Alt_R:
+      return ibus::MOD1_MASK;
+    case ibus::Eisu_toggle:
+    default:
+      return 0;
+  }
+}
+
+// 修饰键（Shift/Alt）：ascii_composer 在 release 时触发动作，需要发 press+release。
+// Toggle 键（Eisu_toggle）：ascii_composer 在 press 时立即触发，release 会再次触发
+// 导致动作执行两次相互抵消；只发 press 即可。
+static bool should_send_release(UINT32 keycode) {
+  switch (keycode) {
+    case ibus::Shift_L:
+    case ibus::Shift_R:
+    case ibus::Alt_L:
+    case ibus::Alt_R:
+      return true;
+    default:
+      return false;
+  }
+}
+
 HRESULT CCompartmentEventSink::_Advise(_In_ com_ptr<IUnknown> punk,
                                        _In_ REFGUID guidCompartment) {
   HRESULT hr = S_OK;
@@ -260,29 +290,39 @@ HRESULT WeaselTSF::_HandleCompartment(REFGUID guidCompartment) {
 
       // Ctrl+Space bypasses the normal key pipeline, so configured
       // key_binder/ascii_composer bindings never see it. Instead synthesize
-      // a pure Shift_L press/release here and let librime's ascii_composer
-      // handle the switch according to its switch_key/Shift_L setting
-      // (commit_code by default).
+      // a configurable keycode (default Shift_L) press/release here and let
+      // librime's ascii_composer handle the switch according to its
+      // switch_key/<keycode> setting (commit_code by default).
+      //
+      // The synthesized keycode comes from weasel.yaml::ctrl_space_key via
+      // server-side Config. 0 means explicitly disabled.
       //
       // Pre-release both Ctrl keys first: the user is physically holding
       // Ctrl while pressing Space, so Ctrl_L is in librime's pending
-      // switch_key set. Without clearing it, the Shift_L release wouldn't
-      // be "pure" and ascii_composer would ignore it.
-      if (_pEditSessionContext && _EnsureServerConnected()) {
+      // switch_key set. Without clearing it, the synthesized release
+      // wouldn't be "pure" and ascii_composer would ignore it.
+      UINT32 keycode = _config.ctrl_space_keycode;
+      if (keycode != 0 && _pEditSessionContext && _EnsureServerConnected()) {
         m_client.ProcessKeyEvent(
             weasel::KeyEvent{ibus::Control_L, ibus::RELEASE_MASK});
         m_client.ProcessKeyEvent(
             weasel::KeyEvent{ibus::Control_R, ibus::RELEASE_MASK});
 
-        // Match ConvertKeyEvent's output for a real Shift press/release:
-        //   press  -> SHIFT_MASK set (Shift is currently down)
-        //   release-> RELEASE_MASK only (Shift no longer down)
-        m_client.ProcessKeyEvent(
-            weasel::KeyEvent{ibus::Shift_L, ibus::SHIFT_MASK});
-        m_client.ProcessKeyEvent(
-            weasel::KeyEvent{ibus::Shift_L, ibus::RELEASE_MASK});
+        // Match ConvertKeyEvent's output for a real key press/release:
+        //   press  -> corresponding modifier mask (or 0 for non-modifier)
+        //   release-> RELEASE_MASK only
+        UINT32 pmask = press_mask_for(keycode);
+        m_client.ProcessKeyEvent(weasel::KeyEvent{keycode, pmask});
+        if (should_send_release(keycode)) {
+          m_client.ProcessKeyEvent(
+              weasel::KeyEvent{keycode, ibus::RELEASE_MASK});
+        }
 
         _UpdateComposition(_pEditSessionContext);
+      } else if (keycode == 0) {
+        // Explicitly disabled via ctrl_space_key: disable/none. Keep the
+        // keyboard open and refresh the language bar, but don't toggle
+        // ascii mode.
       } else {
         // No active edit session context: just toggle ascii_mode locally
         // and tell the server via the tray command path.
@@ -299,7 +339,7 @@ HRESULT WeaselTSF::_HandleCompartment(REFGUID guidCompartment) {
                          GUID_COMPARTMENT_KEYBOARD_INPUTMODE_CONVERSION)) {
     BOOL isOpen = _IsKeyboardOpen();
     if (isOpen) {
-      weasel::ResponseParser parser(NULL, NULL, &_status, NULL,
+      weasel::ResponseParser parser(NULL, NULL, &_status, &_config,
                                     &_cand->style());
       bool ok = m_client.GetResponseData(std::ref(parser));
       _UpdateLanguageBar(_status);

--- a/WeaselTSF/Compartment.cpp
+++ b/WeaselTSF/Compartment.cpp
@@ -3,6 +3,7 @@
 #include "Compartment.h"
 #include <resource.h>
 #include <functional>
+#include <KeyEvent.h>
 #include "ResponseParser.h"
 #include "CandidateList.h"
 #include "LanguageBar.h"
@@ -253,16 +254,46 @@ HRESULT WeaselTSF::_HandleCompartment(REFGUID guidCompartment) {
       _EnableLanguageBar(isOpen);
       _UpdateLanguageBar(_status);
     } else {
-      _status.ascii_mode = !_status.ascii_mode;
+      // Restore keyboard open first so the server won't drop subsequent
+      // key events as "keyboard closed".
       _SetKeyboardOpen(true);
+
+      // Ctrl+Space bypasses the normal key pipeline, so configured
+      // key_binder/ascii_composer bindings never see it. Instead synthesize
+      // a pure Shift_L press/release here and let librime's ascii_composer
+      // handle the switch according to its switch_key/Shift_L setting
+      // (commit_code by default).
+      //
+      // Pre-release both Ctrl keys first: the user is physically holding
+      // Ctrl while pressing Space, so Ctrl_L is in librime's pending
+      // switch_key set. Without clearing it, the Shift_L release wouldn't
+      // be "pure" and ascii_composer would ignore it.
+      if (_pEditSessionContext && _EnsureServerConnected()) {
+        m_client.ProcessKeyEvent(
+            weasel::KeyEvent{ibus::Control_L, ibus::RELEASE_MASK});
+        m_client.ProcessKeyEvent(
+            weasel::KeyEvent{ibus::Control_R, ibus::RELEASE_MASK});
+
+        // Match ConvertKeyEvent's output for a real Shift press/release:
+        //   press  -> SHIFT_MASK set (Shift is currently down)
+        //   release-> RELEASE_MASK only (Shift no longer down)
+        m_client.ProcessKeyEvent(
+            weasel::KeyEvent{ibus::Shift_L, ibus::SHIFT_MASK});
+        m_client.ProcessKeyEvent(
+            weasel::KeyEvent{ibus::Shift_L, ibus::RELEASE_MASK});
+
+        _UpdateComposition(_pEditSessionContext);
+      } else {
+        // No active edit session context: just toggle ascii_mode locally
+        // and tell the server via the tray command path.
+        _status.ascii_mode = !_status.ascii_mode;
+        _HandleLangBarMenuSelect(_status.ascii_mode
+                                     ? ID_WEASELTRAY_ENABLE_ASCII
+                                     : ID_WEASELTRAY_DISABLE_ASCII);
+        _UpdateLanguageBar(_status);
+      }
       if (_pLangBarButton && _pLangBarButton->IsLangBarDisabled())
         _EnableLanguageBar(true);
-      _HandleLangBarMenuSelect(_status.ascii_mode
-                                   ? ID_WEASELTRAY_ENABLE_ASCII
-                                   : ID_WEASELTRAY_DISABLE_ASCII);
-      if (_pEditSessionContext)
-        m_client.ClearComposition();
-      _UpdateLanguageBar(_status);
     }
   } else if (IsEqualGUID(guidCompartment,
                          GUID_COMPARTMENT_KEYBOARD_INPUTMODE_CONVERSION)) {

--- a/WeaselTSF/WeaselTSF.cpp
+++ b/WeaselTSF/WeaselTSF.cpp
@@ -1,4 +1,4 @@
-﻿#include "stdafx.h"
+#include "stdafx.h"
 
 #include <WeaselIPCData.h>
 #include <thread>
@@ -176,7 +176,8 @@ STDMETHODIMP WeaselTSF::OnSetThreadFocus() {
   _isToOpenClose = (_ToggleImeOnOpenClose == L"yes");
   if (m_client.Echo()) {
     m_client.ProcessKeyEvent(0);
-    weasel::ResponseParser parser(NULL, NULL, &_status, NULL, &_cand->style());
+    weasel::ResponseParser parser(NULL, NULL, &_status, &_config,
+                                  &_cand->style());
     bool ok = m_client.GetResponseData(std::ref(parser));
     if (ok)
       _UpdateLanguageBar(_status);
@@ -226,7 +227,8 @@ void WeaselTSF::_Reconnect() {
   m_client.Disconnect();
   m_client.Connect(NULL);
   m_client.StartSession();
-  weasel::ResponseParser parser(NULL, NULL, &_status, NULL, &_cand->style());
+  weasel::ResponseParser parser(NULL, NULL, &_status, &_config,
+                                &_cand->style());
   bool ok = m_client.GetResponseData(std::ref(parser));
   if (ok) {
     _UpdateLanguageBar(_status);

--- a/WeaselTSF/WeaselTSF.h
+++ b/WeaselTSF/WeaselTSF.h
@@ -227,6 +227,8 @@ class WeaselTSF : public ITfTextInputProcessorEx,
 
   /* IME status */
   weasel::Status _status;
+  /* 从服务端同步的配置（含 Ctrl+Space 合成 keycode 等） */
+  weasel::Config _config;
 
   // guidatom for the display attibute.
   TfGuidAtom _gaDisplayAttributeInput;

--- a/include/RimeWithWeasel.h
+++ b/include/RimeWithWeasel.h
@@ -120,4 +120,7 @@ class RimeWithWeaselHandler : public weasel::RequestHandler {
   bool m_global_ascii_mode;
   int m_show_notifications_time;
   DWORD m_pid;
+  // Ctrl+Space 合成事件 keycode，默认 Shift_L（保持旧行为）。
+  // weasel.yaml::ctrl_space_key 配置在 Initialize() 中解析覆盖。
+  UINT32 m_ctrl_space_keycode;
 };

--- a/include/WeaselIPCData.h
+++ b/include/WeaselIPCData.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 #include <string>
 #include <vector>
@@ -187,9 +187,14 @@ struct Status {
 
 // 用於向前端告知設置信息
 struct Config {
-  Config() : inline_preedit(false) {}
-  void reset() { inline_preedit = false; }
+  Config() : inline_preedit(false), ctrl_space_keycode(0) {}
+  void reset() {
+    inline_preedit = false;
+    ctrl_space_keycode = 0;
+  }
   bool inline_preedit;
+  // Ctrl+Space 合成事件的 keycode；0 表示未设置/禁用，消费端决定默认值
+  unsigned int ctrl_space_keycode;
 };
 
 struct UIStyle {

--- a/output/data/weasel.yaml
+++ b/output/data/weasel.yaml
@@ -17,6 +17,14 @@ show_notifications_time: 1200
 # use global ascii status
 global_ascii: false
 
+# Ctrl+Space 合成哪个按键事件。最终行为由 default.yaml 里
+# ascii_composer/switch_key/<key> 决定（默认 commit_code，可改为
+# inline_ascii / commit_text / clear / set_ascii_mode /
+# unset_ascii_mode / noop）。
+# 可选 key: Shift_L (默认), Shift_R, Alt_L, Alt_R, Eisu_toggle, disable
+# 推荐 Eisu_toggle：无物理按键映射，可独立配置、无冲突
+ctrl_space_key: Shift_L
+
 style:
   antialias_mode: default
   ascii_tip_follow_cursor: false

--- a/output/data/weasel.yaml
+++ b/output/data/weasel.yaml
@@ -17,14 +17,6 @@ show_notifications_time: 1200
 # use global ascii status
 global_ascii: false
 
-# Ctrl+Space 合成哪个按键事件。最终行为由 default.yaml 里
-# ascii_composer/switch_key/<key> 决定（默认 commit_code，可改为
-# inline_ascii / commit_text / clear / set_ascii_mode /
-# unset_ascii_mode / noop）。
-# 可选 key: Shift_L (默认), Shift_R, Alt_L, Alt_R, Eisu_toggle, disable
-# 推荐 Eisu_toggle：无物理按键映射，可独立配置、无冲突
-ctrl_space_key: Shift_L
-
 style:
   antialias_mode: default
   ascii_tip_follow_cursor: false


### PR DESCRIPTION
## 背景

关联 issue：rime/weasel#1843

Ctrl+Space 在 Windows TSF 层触发 `GUID_COMPARTMENT_KEYBOARD_OPENCLOSE` 信号，由 `Compartment.cpp::_HandleCompartment` 处理，完全绕过 librime 的键盘事件管线，因此 `key_binder` 和 `ascii_composer/switch_key` 的配置对它无效。

原实现固定合成 `Shift_L` press/release 来触发 ascii_composer，导致 Shift_L 的物理按键行为与 Ctrl+Space 强绑定，无法独立配置切换语义（commit_code / inline_ascii / clear 等）。

## 改动

### 新增配置项 `ctrl_space_key`（`weasel.yaml`）

```yaml
# 可选值：Shift_L（默认）, Shift_R, Alt_L, Alt_R, Eisu_toggle, disable/none
ctrl_space_key: Shift_L
```

配合 `default.yaml` 中对应 switch_key 的语义配置，即可实现 commit_code、inline_ascii 等任意行为：

```yaml
# default.yaml 或 default.custom.yaml
ascii_composer:
  switch_key:
    Shift_L: commit_code   # 或 inline_ascii / clear 等
```

推荐使用 `Eisu_toggle`：该键无标准物理映射，可完全独立配置、与其他按键零冲突。

| 值 | 说明 |
|---|---|
| `Shift_L`（默认） | 合成左 Shift，保持原有行为 |
| `Shift_R` | 合成右 Shift |
| `Alt_L` / `Alt_R` | 合成 Alt |
| `Eisu_toggle` | 合成英数键，推荐用于独立配置 |
| `disable` / `none` | 禁用 Ctrl+Space 的 ascii 切换 |

### 实现细节

- **修饰键（Shift/Alt）**：ascii_composer 在 release 时触发，需发 press + release
- **Toggle 键（Eisu_toggle）**：ascii_composer 在 press 时立即触发，再发 release 会导致动作执行两次相互抵消，故只发 press
- 合成键发送前先发 `Ctrl_L` / `Ctrl_R` release，清除 librime pending switch_key 状态，防止 ascii_composer 忽略合成事件
- `keycode` 经 IPC Config 由服务端（`weasel.yaml` 读取）下发到客户端，刷新配置无需重启进程

### Bug 修复

`WeaselIPC/Configurator.cpp`：null check 误用 `p_context` 改为正确的 `p_config`。

## 文件改动

| 文件 | 改动 |
|---|---|
| `include/WeaselIPCData.h` | `Config` 增加 `ctrl_space_keycode` 字段 |
| `include/RimeWithWeasel.h` | `RimeWithWeaselHandler` 增加 `m_ctrl_space_keycode` 成员 |
| `RimeWithWeasel/RimeWithWeasel.cpp` | 读取配置、下发 keycode |
| `WeaselIPC/Configurator.cpp` | 解析新字段 + null check bug fix |
| `WeaselTSF/WeaselTSF.h` | 增加 `_config` 成员 |
| `WeaselTSF/WeaselTSF.cpp` | `ResponseParser` 传入 `&_config` |
| `WeaselTSF/Compartment.cpp` | 合成逻辑改用可配置 keycode |
| `output/data/weasel.yaml` | 新增 `ctrl_space_key` 示例及注释 |