### PR TITLE
优化候选窗重复显示与定位更新

### DIFF
--- a/WeaselUI/WeaselPanel.cpp
+++ b/WeaselUI/WeaselPanel.cpp
@@ -1156,6 +1156,8 @@ LRESULT WeaselPanel::OnDestroy(UINT uMsg,
   m_hoverIndex = -1;
   m_lastMousePos = {-1, -1};
   m_sticky = false;
+  m_lastWindowPos = {-1, -1};
+  m_hasLastWindowPos = false;
   delete m_layout;
   m_layout = NULL;
   return 0;
@@ -1287,6 +1289,11 @@ void WeaselPanel::_RepositionWindow(const bool& adj) {
     y = rcWorkArea.top;  // over workarea top
   // memorize adjusted position (to avoid window bouncing on height change)
   m_inputPos.bottom = y;
+  if (m_hasLastWindowPos && m_lastWindowPos.x == x && m_lastWindowPos.y == y &&
+      !m_redraw_by_monitor_change)
+    return;
+  m_lastWindowPos = {x, y};
+  m_hasLastWindowPos = true;
   SetWindowPos(HWND_TOPMOST, x, y, 0, 0,
                SWP_NOSIZE | SWP_NOACTIVATE | SWP_NOREDRAW);
 }

--- a/WeaselUI/WeaselPanel.h
+++ b/WeaselUI/WeaselPanel.h
@@ -113,6 +113,8 @@ class WeaselPanel
   const bool& m_in_server;
 
   CRect m_inputPos;
+  CPoint m_lastWindowPos = {-1, -1};
+  bool m_hasLastWindowPos = false;
   int m_offsetys[MAX_CANDIDATES_COUNT];  // offset y for candidates when
                                          // vertical layout over bottom
   int m_offsety_preedit;

--- a/WeaselUI/WeaselUI.cpp
+++ b/WeaselUI/WeaselUI.cpp
@@ -39,23 +39,29 @@ UINT_PTR UIImpl::timer = 0;
 void UIImpl::Show() {
   if (!panel.IsWindow())
     return;
-  panel.ShowWindow(SW_SHOWNA);
+  bool already_shown = shown && panel.IsWindowVisible();
   shown = true;
   if (timer) {
     KillTimer(panel.m_hWnd, AUTOHIDE_TIMER);
     timer = 0;
   }
+  if (already_shown)
+    return;
+  panel.ShowWindow(SW_SHOWNA);
 }
 
 void UIImpl::Hide() {
   if (!panel.IsWindow())
     return;
-  panel.ShowWindow(SW_HIDE);
+  bool already_hidden = !shown && !panel.IsWindowVisible();
   shown = false;
   if (timer) {
     KillTimer(panel.m_hWnd, AUTOHIDE_TIMER);
     timer = 0;
   }
+  if (already_hidden)
+    return;
+  panel.ShowWindow(SW_HIDE);
 }
 
 void UIImpl::ShowWithTimeout(size_t millisec) {


### PR DESCRIPTION
## 做了什么

这次主要减少候选窗在输入过程中的重复 UI 操作：

- 候选窗已经显示时，不再重复调用 `ShowWindow(SW_SHOWNA)`；
- 候选窗已经隐藏时，不再重复调用 `ShowWindow(SW_HIDE)`；
- 候选窗最终位置没有变化时，不再重复调用 `SetWindowPos`；
- 保留原有自动隐藏 timer 的清理逻辑，尽量不改变现有行为。

## 解决的问题

在一些长期运行的宿主程序里，比如 Chrome，用小狼毫输入时，候选窗出现会逐渐变得有明显阻尼感。

本地排查发现，慢点不在 librime 取候选结果，而主要在候选窗 UI 的显示、更新和定位路径上。宿主窗口运行时间长了以后，重复 `ShowWindow` / `SetWindowPos` 的开销会被放大，导致按键后候选窗出来得慢。

这个改动就是跳过明显没有必要的重复窗口状态更新，降低每次输入触发的 UI 开销。

## 本地对比

在本地带插桩版本中，对 Chrome 里已经变卡的窗口和修复后的新窗口做过对比，核心路径大概是：

- `show` 平均耗时：`24.08ms -> 2.58ms`
- `cand_update` 平均耗时：`22.45ms -> 3.98ms`
- `CandidateList.UpdateInputPosition` 平均耗时：`25.41ms -> 11.74ms`
- `UpdateComposition` 平均耗时：`99.60ms -> 35.18ms`

体感上，候选窗弹出的阻尼明显下降。

## 说明

这不是改输入逻辑，也不改候选生成逻辑，只是减少候选窗层面的重复窗口操作。