### PR TITLE
移除 ShellExecuteW 路径中的错误的引号

### DIFF
--- a/WeaselTSF/LanguageBar.cpp
+++ b/WeaselTSF/LanguageBar.cpp
@@ -45,9 +45,8 @@ static LPCWSTR GetWeaselRegName() {
 }
 
 static bool open(const std::wstring& path) {
-  std::wstring quoted_path = L"\"" + path + L"\"";
-  return (uintptr_t)ShellExecuteW(NULL, L"open", quoted_path.c_str(), NULL,
-                                  NULL, SW_SHOWNORMAL) > 32;
+  return (uintptr_t)ShellExecuteW(NULL, L"open", path.c_str(), NULL, NULL,
+                                  SW_SHOWNORMAL) > 32;
 }
 
 CLangBarItemButton::CLangBarItemButton(com_ptr<WeaselTSF> pTextService,


### PR DESCRIPTION
根据微软 MSDN 规范，`ShellExecuteW` 的 `lpFile` 参数在设计上仅接收纯粹的文件或对象路径，不需要（也不应该）像命令行那样用双引号处理空格。
并且增加双引号会导致，第三方文件管理器无法接管