### PR TITLE
优化 WeaselTSF：跳过重复的候选窗位置更新

### DIFF
--- a/WeaselIPC/WeaselClientImpl.cpp
+++ b/WeaselIPC/WeaselClientImpl.cpp
@@ -126,15 +126,24 @@ void ClientImpl::UpdateInputPosition(RECT const& rc) {
   int height = max(0, min(127, (rc.bottom - rc.top) >> hi_res));
   DWORD compressed_rect = ((hi_res & 0x01) << 31) | ((height & 0x7f) << 24) |
                           ((top & 0xfff) << 12) | (left & 0xfff);
+  if (has_last_input_position && last_input_position_session == session_id &&
+      last_input_position_rect == compressed_rect) {
+    return;
+  }
+  has_last_input_position = true;
+  last_input_position_session = session_id;
+  last_input_position_rect = compressed_rect;
   _SendMessage(WEASEL_IPC_UPDATE_INPUT_POS, compressed_rect, session_id);
 }
 
 void ClientImpl::FocusIn() {
+  has_last_input_position = false;
   DWORD client_caps = 0; /* TODO */
   _SendMessage(WEASEL_IPC_FOCUS_IN, client_caps, session_id);
 }
 
 void ClientImpl::FocusOut() {
+  has_last_input_position = false;
   _SendMessage(WEASEL_IPC_FOCUS_OUT, 0, session_id);
 }
 
@@ -149,21 +158,25 @@ void ClientImpl::StartSession() {
   _WriteClientInfo();
   UINT ret = _SendMessage(WEASEL_IPC_START_SESSION, 0, 0);
   session_id = ret;
+  has_last_input_position = false;
 }
 
 void ClientImpl::EndSession() {
   _SendMessage(WEASEL_IPC_END_SESSION, 0, session_id);
   session_id = 0;
+  has_last_input_position = false;
 }
 
 void ClientImpl::StartMaintenance() {
   _SendMessage(WEASEL_IPC_START_MAINTENANCE, 0, 0);
   session_id = 0;
+  has_last_input_position = false;
 }
 
 void ClientImpl::EndMaintenance() {
   _SendMessage(WEASEL_IPC_END_MAINTENANCE, 0, 0);
   session_id = 0;
+  has_last_input_position = false;
 }
 
 bool ClientImpl::Echo() {

--- a/WeaselIPC/WeaselClientImpl.h
+++ b/WeaselIPC/WeaselClientImpl.h
@@ -42,6 +42,9 @@ class ClientImpl {
   UINT session_id;
   std::wstring app_name;
   bool is_ime;
+  bool has_last_input_position = false;
+  UINT last_input_position_session = 0;
+  DWORD last_input_position_rect = 0;
 
   PipeChannel<PipeMessage> channel;
 };

--- a/WeaselTSF/Composition.cpp
+++ b/WeaselTSF/Composition.cpp
@@ -72,6 +72,7 @@ STDAPI CStartCompositionEditSession::DoEditSession(TfEditCookie ec) {
 
 void WeaselTSF::_StartComposition(com_ptr<ITfContext> pContext,
                                   BOOL fCUASWorkaroundEnabled) {
+  _hasLastCompositionPosition = FALSE;
   com_ptr<CStartCompositionEditSession> pStartCompositionEditSession;
   pStartCompositionEditSession.Attach(new CStartCompositionEditSession(
       this, pContext, fCUASWorkaroundEnabled, _cand->style().inline_preedit));
@@ -239,6 +240,17 @@ void WeaselTSF::_SetCompositionPosition(const RECT& rc) {
       return;
     }
   }
+  BOOL same_position = _hasLastCompositionPosition &&
+                       _lastCompositionPosition.left == rc.left &&
+                       _lastCompositionPosition.top == rc.top &&
+                       _lastCompositionPosition.right == rc.right &&
+                       _lastCompositionPosition.bottom == rc.bottom;
+  if (same_position) {
+    return;
+  }
+  _lastCompositionPosition = rc;
+  _hasLastCompositionPosition = TRUE;
+
   RECT _rc;
   _rc.left = _rc.right = rc.left;
   _rc.top = _rc.bottom = rc.bottom;
@@ -404,6 +416,7 @@ STDAPI WeaselTSF::OnCompositionTerminated(TfEditCookie ecWrite,
 }
 
 void WeaselTSF::_AbortComposition(bool clear) {
+  _hasLastCompositionPosition = FALSE;
   m_client.ClearComposition();
   if (_IsComposing()) {
     _EndComposition(_pEditSessionContext, clear);

--- a/WeaselTSF/KeyEventSink.cpp
+++ b/WeaselTSF/KeyEventSink.cpp
@@ -63,6 +63,7 @@ void WeaselTSF::_ProcessKeyEvent(WPARAM wParam, LPARAM lParam, BOOL* pfEaten) {
 }
 
 STDAPI WeaselTSF::OnSetFocus(BOOL fForeground) {
+  _hasLastCompositionPosition = false;
   if (fForeground)
     m_client.FocusIn();
   else {

--- a/WeaselTSF/WeaselTSF.h
+++ b/WeaselTSF/WeaselTSF.h
@@ -233,4 +233,6 @@ class WeaselTSF : public ITfTextInputProcessorEx,
   BOOL _async_edit = false;
   BOOL _committed = false;
   BOOL _isToOpenClose = false;
+  BOOL _hasLastCompositionPosition = false;
+  RECT _lastCompositionPosition = {0, 0, 0, 0};
 };


### PR DESCRIPTION
## 摘要

- 在 `WeaselTSF` 侧缓存上一次候选窗/组字位置。
- 在 `WeaselIPC` 侧缓存上一次压缩后的输入位置消息。
- 当有效位置没有变化时，跳过重复的位置更新。
- 在焦点、会话和组字生命周期边界重置缓存。

## 背景

快速输入时，候选窗位置更新链路会出现大量“实际位置未变化”的重复调用。本地测试样本中：

- 桌面应用输入框：重复候选位置更新约 `85%`。
- 微信输入框：重复候选位置更新约 `82%`。

这些重复更新会继续进入 IPC 和候选窗更新链路，即使候选窗实际位置没有变化。本 PR 只在 TSF/IPC 边界过滤等价的位置更新，用来减少无意义的消息和窗口更新压力。

## 改动边界

- 不改变候选内容、候选排序、分页和选择逻辑。
- 不改变候选窗布局计算。
- 不改变候选窗显示/隐藏策略。
- 位置缓存会在焦点、会话和组字边界清空，避免跨上下文复用旧位置。

## 与已有 PR 的关系

与 #1869 都属于候选窗性能方向，但处理层级不同：#1869 更靠近 UI 层，本 PR 在 TSF/IPC 边界减少重复位置消息。

## 测试

- 已对修改文件运行 `clang-format --style=file --Werror --dry-run`。
- 已本地运行 `xmake f -a x64 -m release && xmake`。
- 已验证 `WeaselTSF` 和 `WeaselIPC` 相关代码路径可编译。