### PR TITLE
优化 WeaselUI：预热并复用候选窗 DirectWrite 资源

### DIFF
--- a/WeaselTSF/CandidateList.cpp
+++ b/WeaselTSF/CandidateList.cpp
@@ -218,6 +218,7 @@ void CCandidateList::UpdateUI(const Context& ctx, const Status& status) {
 }
 
 void CCandidateList::UpdateStyle(const UIStyle& sty) {
+  _style = sty;
   _ui->style() = sty;
 }
 
@@ -236,6 +237,16 @@ void CCandidateList::DestroyAll() {
   Show(FALSE);
   _DisposeUIWindowAll();
 }
+
+void CCandidateList::PrewarmUIResources() {
+  if (_ui == nullptr || _style.font_point <= 0) {
+    return;
+  }
+
+  _ui->style() = _style;
+  _ui->Prewarm();
+}
+
 UIStyle& CCandidateList::style() {
   // return _ui->style();
   return _style;

--- a/WeaselTSF/CandidateList.h
+++ b/WeaselTSF/CandidateList.h
@@ -54,6 +54,7 @@ class CCandidateList : public ITfIntegratableCandidateListUIElement,
   void DestroyAll();
   void StartUI();
   void EndUI();
+  void PrewarmUIResources();
 
   com_ptr<ITfContext> GetContextDocument();
   bool GetIsReposition() {

--- a/WeaselTSF/KeyEventSink.cpp
+++ b/WeaselTSF/KeyEventSink.cpp
@@ -63,9 +63,10 @@ void WeaselTSF::_ProcessKeyEvent(WPARAM wParam, LPARAM lParam, BOOL* pfEaten) {
 }
 
 STDAPI WeaselTSF::OnSetFocus(BOOL fForeground) {
-  if (fForeground)
+  if (fForeground) {
     m_client.FocusIn();
-  else {
+    _cand->PrewarmUIResources();
+  } else {
     m_client.FocusOut();
     _AbortComposition();
   }

--- a/WeaselTSF/WeaselTSF.cpp
+++ b/WeaselTSF/WeaselTSF.cpp
@@ -160,7 +160,9 @@ STDAPI WeaselTSF::ActivateEx(ITfThreadMgr* pThreadMgr,
   if (!_InitThreadFocusSink())
     goto ExitError;
 
-  _EnsureServerConnected();
+  if (_EnsureServerConnected()) {
+    _cand->PrewarmUIResources();
+  }
 
   return S_OK;
 
@@ -178,8 +180,10 @@ STDMETHODIMP WeaselTSF::OnSetThreadFocus() {
     m_client.ProcessKeyEvent(0);
     weasel::ResponseParser parser(NULL, NULL, &_status, NULL, &_cand->style());
     bool ok = m_client.GetResponseData(std::ref(parser));
-    if (ok)
+    if (ok) {
       _UpdateLanguageBar(_status);
+      _cand->PrewarmUIResources();
+    }
   }
   return S_OK;
 }

--- a/WeaselUI/WeaselPanel.h
+++ b/WeaselUI/WeaselPanel.h
@@ -141,7 +141,7 @@ class WeaselPanel
   bool hide_candidates;
   bool m_sticky;
   // for multi font_face & font_point
-  PDWR pDWR;
+  PDWR& pDWR;
   std::function<void(size_t* const, size_t* const, bool* const, bool* const)>&
       _UICallback;
   float bar_scale_ = 1.0;

--- a/WeaselUI/WeaselUI.cpp
+++ b/WeaselUI/WeaselUI.cpp
@@ -1,8 +1,78 @@
 #include "stdafx.h"
 #include <WeaselUI.h>
+#include <ShellScalingApi.h>
 #include "WeaselPanel.h"
 
+#pragma comment(lib, "Shcore.lib")
+
 using namespace weasel;
+
+static UINT GetDefaultDpiForPrewarm() {
+  RECT rc = {};
+  HMONITOR hMonitor = MonitorFromRect(&rc, MONITOR_DEFAULTTONEAREST);
+  UINT dpiX = 96, dpiY = 96;
+  if (hMonitor) {
+    GetDpiForMonitor(hMonitor, MDT_EFFECTIVE_DPI, &dpiX, &dpiY);
+  }
+  return dpiX;
+}
+
+static bool WarmUpDwrEndDraw(PDWR& pDWR) {
+  if (!pDWR || !pDWR->pRenderTarget) {
+    return false;
+  }
+
+  constexpr int kWidth = 96;
+  constexpr int kHeight = 32;
+  HDC screen_dc = ::GetDC(NULL);
+  HDC mem_dc = screen_dc ? ::CreateCompatibleDC(screen_dc) : NULL;
+  HBITMAP bitmap =
+      screen_dc ? ::CreateCompatibleBitmap(screen_dc, kWidth, kHeight) : NULL;
+  HGDIOBJ old_bitmap = NULL;
+  bool ok = false;
+
+  if (mem_dc && bitmap) {
+    old_bitmap = ::SelectObject(mem_dc, bitmap);
+    RECT rc = {0, 0, kWidth, kHeight};
+    HRESULT hr = pDWR->pRenderTarget->BindDC(mem_dc, &rc);
+    if (SUCCEEDED(hr)) {
+      pDWR->pRenderTarget->BeginDraw();
+      if (!pDWR->pBrush) {
+        pDWR->CreateBrush(D2D1::ColorF(0, 0, 0, 1));
+      } else {
+        pDWR->SetBrushColor(D2D1::ColorF(0, 0, 0, 1));
+      }
+
+      IDWriteTextFormat1* format = pDWR->pTextFormat.Get();
+      if (!format) {
+        format = pDWR->pPreeditTextFormat.Get();
+      }
+      if (format) {
+        hr = pDWR->CreateTextLayout(L"warm", 4, format, kWidth, kHeight);
+        if (SUCCEEDED(hr) && pDWR->pTextLayout) {
+          pDWR->DrawTextLayoutAt({0, 0});
+        }
+      }
+      ok = SUCCEEDED(pDWR->pRenderTarget->EndDraw());
+      pDWR->ResetLayout();
+    }
+  }
+
+  if (old_bitmap) {
+    ::SelectObject(mem_dc, old_bitmap);
+  }
+  if (bitmap) {
+    ::DeleteObject(bitmap);
+  }
+  if (mem_dc) {
+    ::DeleteDC(mem_dc);
+  }
+  if (screen_dc) {
+    ::ReleaseDC(NULL, screen_dc);
+  }
+
+  return ok;
+}
 
 class weasel::UIImpl {
  public:
@@ -102,6 +172,32 @@ bool UI::Create(HWND parent) {
   return true;
 }
 
+bool UI::Prewarm() {
+  UINT dpi = GetDefaultDpiForPrewarm();
+  UINT cached_dpi =
+      pDWR ? static_cast<UINT>(pDWR->dpiScaleLayout * 96.0f + 0.5f) : 0;
+  bool need_rebuild = !pDWR || (ostyle_ != style_) || (cached_dpi != dpi);
+
+  if (!need_rebuild) {
+    if (!dwr_warm_drawn_) {
+      dwr_warm_drawn_ = WarmUpDwrEndDraw(pDWR);
+    }
+    return true;
+  }
+
+  pDWR.reset();
+  dwr_warm_drawn_ = false;
+  pDWR = std::make_shared<DirectWriteResources>(style_, dpi);
+  if (pDWR && pDWR->pRenderTarget) {
+    pDWR->pRenderTarget->SetTextAntialiasMode(
+        (D2D1_TEXT_ANTIALIAS_MODE)style_.antialias_mode);
+  }
+  ostyle_ = style_;
+  dwr_warm_drawn_ = WarmUpDwrEndDraw(pDWR);
+
+  return pDWR != nullptr;
+}
+
 void UI::Destroy(bool full) {
   if (pimpl_) {
     // destroy panel
@@ -112,6 +208,7 @@ void UI::Destroy(bool full) {
       delete pimpl_;
       pimpl_ = 0;
       pDWR.reset();
+      dwr_warm_drawn_ = false;
     }
   }
 }

--- a/include/WeaselUI.h
+++ b/include/WeaselUI.h
@@ -27,7 +27,7 @@ using PDWR = an<DirectWriteResources>;
 //
 class UI {
  public:
-  UI() : pimpl_(0), in_server_(false) {}
+  UI() : pimpl_(0), in_server_(false), dwr_warm_drawn_(false) {}
 
   virtual ~UI() {
     if (pimpl_)
@@ -58,13 +58,14 @@ class UI {
 
   // 更新界面显示内容
   void Update(Context const& ctx, Status const& status);
+  bool Prewarm();
 
   Context& ctx() { return ctx_; }
   Context& octx() { return octx_; }
   Status& status() { return status_; }
   UIStyle& style() { return style_; }
   UIStyle& ostyle() { return ostyle_; }
-  PDWR pdwr() { return pDWR; }
+  PDWR& pdwr() { return pDWR; }
   bool GetIsReposition();
   bool& InServer() { return in_server_; }
 
@@ -82,6 +83,7 @@ class UI {
  private:
   UIImpl* pimpl_;
   PDWR pDWR;
+  bool dwr_warm_drawn_;
 
   Context ctx_;
   Context octx_;


### PR DESCRIPTION
## 摘要

- 新增 `UI::Prewarm()`，在首次候选窗渲染前初始化 `DirectWriteResources`。
- 执行一次很小的离屏 DirectWrite 绘制，让首次可见绘制少承担初始化成本。
- 让 `WeaselPanel` 复用 `UI` 持有的 `PDWR`，避免预热资源和真实候选窗资源分离。
- 在服务/状态同步后，以及文本服务获得焦点时触发预热。

## 背景

本地排查发现，首次显示候选窗时，Direct2D 的 DC render target 创建可能落在按键同步路径里。代表样本如下：

- 桌面应用输入框：`tsf.on_key_down` 总耗时 `280.56ms`，其中 `ID2D1Factory::CreateDCRenderTarget` 耗时 `247.77ms`。
- 微信输入框：`tsf.on_test_key_down` 总耗时 `192.03ms`，其中 `ID2D1Factory::CreateDCRenderTarget` 耗时 `166.99ms`。

这段耗时发生在候选 UI 启动期间，用户体感上就是首次候选窗出现时输入卡顿。本 PR 将这部分资源准备尽量提前，并让真实候选面板复用预热后的资源，避免首次可见候选窗渲染在同一个按键同步路径上承担完整初始化成本。

## 改动边界

- 不改变候选内容、候选排序、分页和选择逻辑。
- 不改变候选窗布局算法。
- 不改变候选窗创建/销毁语义。
- 不改变 IPC 消息协议。
- 只调整候选窗渲染资源的准备和复用方式。

## 与已有 PR 的关系

与 #1839 都涉及候选面板生命周期，但本 PR 不改变 `UI::Create()` 的幂等行为，也不改变面板销毁语义。

与 #1869 都属于候选窗性能方向，但处理点不同：#1869 更关注候选窗重复显示和定位，本 PR 关注 DirectWrite/Direct2D 渲染资源的预热与复用。

## 测试

- 已对修改文件运行 `clang-format --style=file --Werror --dry-run`。
- 已本地运行 `xmake f -a x64 -m release && xmake`。
- 已验证 `WeaselUI` 和 `WeaselTSF` 相关代码路径可编译。