### PR TITLE
feat: support configurable keyboard layouts on Windows

### DIFF
--- a/RimeWithWeasel/RimeWithWeasel.cpp
+++ b/RimeWithWeasel/RimeWithWeasel.cpp
@@ -40,6 +40,7 @@ RimeWithWeaselHandler::RimeWithWeaselHandler(UI* ui)
       m_disabled(true),
       m_current_dark_mode(false),
       m_global_ascii_mode(false),
+      m_keyboard_layout("qwerty"),
       m_show_notifications_time(1200),
       _UpdateUICallback(NULL) {
   m_ui->InServer() = true;
@@ -118,6 +119,7 @@ void RimeWithWeaselHandler::Initialize() {
   }
 
   RimeConfig config = {NULL};
+  m_keyboard_layout = "qwerty";
   if (rime_api->config_open("weasel", &config)) {
     if (m_ui) {
       _UpdateUIStyle(&config, m_ui, true);
@@ -137,6 +139,11 @@ void RimeWithWeaselHandler::Initialize() {
     Bool global_ascii = false;
     if (rime_api->config_get_bool(&config, "global_ascii", &global_ascii))
       m_global_ascii_mode = !!global_ascii;
+    char keyboard_layout[32] = {};
+    if (rime_api->config_get_string(&config, "keyboard_layout",
+                                    keyboard_layout,
+                                    sizeof(keyboard_layout) - 1))
+      m_keyboard_layout = keyboard_layout;
     if (!rime_api->config_get_int(&config, "show_notifications_time",
                                   &m_show_notifications_time))
       m_show_notifications_time = 1200;
@@ -897,6 +904,9 @@ bool RimeWithWeaselHandler::_Respond(WeaselSessionId ipc_id, EatLine eat) {
   actions.push_back("config");
   body.append(L"config.inline_preedit=")
       .append(std::to_wstring((int)session_status.style.inline_preedit))
+      .append(L"\n");
+  body.append(L"config.keyboard_layout=")
+      .append(u8tow(m_keyboard_layout))
       .append(L"\n");
 
   // style

--- a/WeaselIPC/Configurator.cpp
+++ b/WeaselIPC/Configurator.cpp
@@ -14,10 +14,12 @@ Configurator::~Configurator() {}
 
 void Configurator::Store(Deserializer::KeyType const& key,
                          std::wstring const& value) {
-  if (!m_pTarget->p_context || key.size() < 2)
+  if (!m_pTarget->p_config || key.size() < 2)
     return;
   bool bool_value = (!value.empty() && value != L"0");
   if (key[1] == L"inline_preedit") {
     m_pTarget->p_config->inline_preedit = bool_value;
+  } else if (key[1] == L"keyboard_layout") {
+    m_pTarget->p_config->keyboard_layout = value;
   }
 }

--- a/WeaselTSF/Compartment.cpp
+++ b/WeaselTSF/Compartment.cpp
@@ -268,7 +268,7 @@ HRESULT WeaselTSF::_HandleCompartment(REFGUID guidCompartment) {
                          GUID_COMPARTMENT_KEYBOARD_INPUTMODE_CONVERSION)) {
     BOOL isOpen = _IsKeyboardOpen();
     if (isOpen) {
-      weasel::ResponseParser parser(NULL, NULL, &_status, NULL,
+      weasel::ResponseParser parser(NULL, NULL, &_status, &_config,
                                     &_cand->style());
       bool ok = m_client.GetResponseData(std::ref(parser));
       _UpdateLanguageBar(_status);

--- a/WeaselTSF/Composition.cpp
+++ b/WeaselTSF/Composition.cpp
@@ -381,6 +381,49 @@ BOOL WeaselTSF::_InsertText(com_ptr<ITfContext> pContext,
   return TRUE;
 }
 
+class CInsertTextAtSelectionEditSession : public CEditSession {
+ public:
+  CInsertTextAtSelectionEditSession(com_ptr<WeaselTSF> pTextService,
+                                    com_ptr<ITfContext> pContext,
+                                    const std::wstring& text)
+      : CEditSession(pTextService, pContext), _text(text) {}
+
+  STDMETHODIMP DoEditSession(TfEditCookie ec) override {
+    TF_SELECTION selection = {};
+    ULONG fetched = 0;
+    if (_pContext->GetSelection(ec, TF_DEFAULT_SELECTION, 1, &selection,
+                                &fetched) != S_OK ||
+        fetched != 1 || !selection.range)
+      return E_FAIL;
+    HRESULT result = selection.range->SetText(
+        ec, TF_ST_CORRECTION, _text.c_str(), static_cast<LONG>(_text.length()));
+    if (SUCCEEDED(result)) {
+      selection.range->Collapse(ec, TF_ANCHOR_END);
+      selection.style.ase = TF_AE_NONE;
+      selection.style.fInterimChar = FALSE;
+      result = _pContext->SetSelection(ec, 1, &selection);
+    }
+    selection.range->Release();
+    return result;
+  }
+
+ private:
+  std::wstring _text;
+};
+
+BOOL WeaselTSF::_InsertTextAtSelection(com_ptr<ITfContext> pContext,
+                                       const std::wstring& text) {
+  com_ptr<CInsertTextAtSelectionEditSession> editSession;
+  editSession.Attach(new CInsertTextAtSelectionEditSession(this, pContext,
+                                                            text));
+  if (!editSession)
+    return FALSE;
+  HRESULT result;
+  return SUCCEEDED(pContext->RequestEditSession(
+      _tfClientId, editSession, TF_ES_ASYNCDONTCARE | TF_ES_READWRITE,
+      &result));
+}
+
 void WeaselTSF::_UpdateComposition(com_ptr<ITfContext> pContext) {
   HRESULT hr;
 

--- a/WeaselTSF/EditSession.cpp
+++ b/WeaselTSF/EditSession.cpp
@@ -6,9 +6,8 @@
 STDAPI WeaselTSF::DoEditSession(TfEditCookie ec) {
   // get commit string from server
   std::wstring commit;
-  weasel::Config config;
   auto context = std::make_shared<weasel::Context>();
-  weasel::ResponseParser parser(&commit, context.get(), &_status, &config,
+  weasel::ResponseParser parser(&commit, context.get(), &_status, &_config,
                                 &_cand->style());
 
   bool ok = m_client.GetResponseData(std::ref(parser));
@@ -21,7 +20,7 @@ STDAPI WeaselTSF::DoEditSession(TfEditCookie ec) {
       // Commit and close the original composition first.
       if (!_IsComposing()) {
         _StartComposition(_pEditSessionContext,
-                          _fCUASWorkaroundEnabled && !config.inline_preedit);
+                          _fCUASWorkaroundEnabled && !_config.inline_preedit);
       }
       _InsertText(_pEditSessionContext, commit);
       _EndComposition(_pEditSessionContext, false);
@@ -31,11 +30,11 @@ STDAPI WeaselTSF::DoEditSession(TfEditCookie ec) {
     }
     if (_status.composing && !_IsComposing()) {
       _StartComposition(_pEditSessionContext,
-                        _fCUASWorkaroundEnabled && !config.inline_preedit);
+                        _fCUASWorkaroundEnabled && !_config.inline_preedit);
     } else if (!_status.composing && _IsComposing()) {
       _EndComposition(_pEditSessionContext, true);
     }
-    if (_IsComposing() && config.inline_preedit) {
+    if (_IsComposing() && _config.inline_preedit) {
       _ShowInlinePreedit(_pEditSessionContext, context);
     }
     _UpdateCompositionWindow(_pEditSessionContext);

--- a/WeaselTSF/KeyEvent.cpp
+++ b/WeaselTSF/KeyEvent.cpp
@@ -1,9 +1,109 @@
 ﻿#include "stdafx.h"
 #include <KeyEvent.h>
 
+UINT RemapKeyByLayout(UINT vkey, UINT scanCode, LPCWSTR layout) {
+  if (!layout)
+    return vkey;
+
+  // Set 1 scan codes for the alphabetic section of a standard PC keyboard.
+  if (_wcsicmp(layout, L"colemak") == 0) {
+    // Unlisted positions have the same meaning in QWERTY and Colemak.
+    switch (scanCode) {
+      case 0x12: return 'F';
+      case 0x13: return 'P';
+      case 0x14: return 'G';
+      case 0x15: return 'J';
+      case 0x16: return 'L';
+      case 0x17: return 'U';
+      case 0x18: return 'Y';
+      case 0x19: return VK_OEM_1;
+      case 0x1f: return 'R';
+      case 0x20: return 'S';
+      case 0x21: return 'T';
+      case 0x22: return 'D';
+      case 0x24: return 'N';
+      case 0x25: return 'E';
+      case 0x26: return 'I';
+      case 0x27: return 'O';
+      case 0x31: return 'K';
+      default: return vkey;
+    }
+  }
+
+  if (_wcsicmp(layout, L"dvorak") == 0) {
+    switch (scanCode) {
+      case 0x10: return VK_OEM_7;       // '
+      case 0x11: return VK_OEM_COMMA;   // ,
+      case 0x12: return VK_OEM_PERIOD;  // .
+      case 0x13: return 'P';
+      case 0x14: return 'Y';
+      case 0x15: return 'F';
+      case 0x16: return 'G';
+      case 0x17: return 'C';
+      case 0x18: return 'R';
+      case 0x19: return 'L';
+      case 0x1a: return VK_OEM_2;       // /
+      case 0x1b: return VK_OEM_PLUS;    // =
+      case 0x1e: return 'A';
+      case 0x1f: return 'O';
+      case 0x20: return 'E';
+      case 0x21: return 'U';
+      case 0x22: return 'I';
+      case 0x23: return 'D';
+      case 0x24: return 'H';
+      case 0x25: return 'T';
+      case 0x26: return 'N';
+      case 0x27: return 'S';
+      case 0x28: return VK_OEM_MINUS;  // -
+      case 0x2c: return VK_OEM_1;     // ;
+      case 0x2d: return 'Q';
+      case 0x2e: return 'J';
+      case 0x2f: return 'K';
+      case 0x30: return 'X';
+      case 0x31: return 'B';
+      case 0x32: return 'M';
+      case 0x33: return 'W';
+      case 0x34: return 'V';
+      case 0x35: return 'Z';
+      default: return vkey;
+    }
+  }
+
+  if (_wcsicmp(layout, L"workman") == 0) {
+    // Unlisted positions have the same meaning in QWERTY and Workman.
+    switch (scanCode) {
+      case 0x11: return 'D';
+      case 0x12: return 'R';
+      case 0x13: return 'W';
+      case 0x14: return 'B';
+      case 0x15: return 'J';
+      case 0x16: return 'F';
+      case 0x17: return 'U';
+      case 0x18: return 'P';
+      case 0x19: return VK_OEM_1;
+      case 0x20: return 'H';
+      case 0x21: return 'T';
+      case 0x23: return 'Y';
+      case 0x24: return 'N';
+      case 0x25: return 'E';
+      case 0x26: return 'O';
+      case 0x27: return 'I';
+      case 0x2e: return 'M';
+      case 0x2f: return 'C';
+      case 0x30: return 'V';
+      case 0x31: return 'K';
+      case 0x32: return 'L';
+      default: return vkey;
+    }
+  }
+
+  return vkey;
+}
+
 bool ConvertKeyEvent(UINT vkey,
                      KeyInfo kinfo,
                      const LPBYTE keyState,
+                     LPCWSTR keyboardLayout,
                      weasel::KeyEvent& result) {
   const BYTE KEY_DOWN = 0x80;
   const BYTE TOGGLED = 0x01;
@@ -41,6 +141,8 @@ bool ConvertKeyEvent(UINT vkey,
     return true;
   }
 
+  vkey = RemapKeyByLayout(vkey, kinfo.scanCode, keyboardLayout);
+
   const int buf_len = 8;
   static WCHAR buf[buf_len];
   static BYTE table[256];
@@ -48,7 +150,8 @@ bool ConvertKeyEvent(UINT vkey,
   memcpy(table, keyState, sizeof(table));
   table[VK_CONTROL] = 0;
   table[VK_MENU] = 0;
-  int ret = ToUnicodeEx(vkey, UINT(kinfo), table, buf, buf_len, 0, NULL);
+  int ret = ToUnicodeEx(vkey, MapVirtualKeyW(vkey, MAPVK_VK_TO_VSC), table, buf,
+                        buf_len, 0, NULL);
   if (ret == 1) {
     result.keycode = UINT(buf[0]);
     return true;

--- a/WeaselTSF/KeyEventSink.cpp
+++ b/WeaselTSF/KeyEventSink.cpp
@@ -22,8 +22,10 @@ void WeaselTSF::_ProcessKeyEvent(WPARAM wParam, LPARAM lParam, BOOL* pfEaten) {
     return;
   }
   weasel::KeyEvent ke;
+  KeyInfo keyInfo(lParam);
   GetKeyboardState(_lpbKeyState);
-  if (!ConvertKeyEvent(static_cast<UINT>(wParam), lParam, _lpbKeyState, ke)) {
+  if (!ConvertKeyEvent(static_cast<UINT>(wParam), keyInfo, _lpbKeyState,
+                       _config.keyboard_layout.c_str(), ke)) {
     /* Unknown key event */
     *pfEaten = FALSE;
   } else {
@@ -36,6 +38,19 @@ void WeaselTSF::_ProcessKeyEvent(WPARAM wParam, LPARAM lParam, BOOL* pfEaten) {
     }
     if (!keyCountToSimulate)
       *pfEaten = (BOOL)m_client.ProcessKeyEvent(ke);
+
+    const UINT remappedVkey = RemapKeyByLayout(
+        static_cast<UINT>(wParam), keyInfo.scanCode,
+        _config.keyboard_layout.c_str());
+    const bool unmodified =
+        !(ke.mask & (ibus::CONTROL_MASK | ibus::ALT_MASK | ibus::META_MASK |
+                     ibus::SUPER_MASK | ibus::RELEASE_MASK));
+    if (!*pfEaten && _status.ascii_mode && !_status.composing && unmodified &&
+        remappedVkey != static_cast<UINT>(wParam) && ke.keycode >= 0x20 &&
+        ke.keycode < 0x7f) {
+      _pendingAsciiText.assign(1, static_cast<wchar_t>(ke.keycode));
+      *pfEaten = TRUE;
+    }
 
     if (ke.keycode == ibus::Caps_Lock) {
       if (prevKeyEvent.keycode == ibus::Caps_Lock && prevfEaten == TRUE &&
@@ -110,6 +125,10 @@ STDAPI WeaselTSF::OnKeyDown(ITfContext* pContext,
   } else {
     _ProcessKeyEvent(wParam, lParam, pfEaten);
     _UpdateComposition(pContext);
+  }
+  if (*pfEaten && !_pendingAsciiText.empty()) {
+    _InsertTextAtSelection(pContext, _pendingAsciiText);
+    _pendingAsciiText.clear();
   }
   return S_OK;
 }

--- a/WeaselTSF/WeaselTSF.cpp
+++ b/WeaselTSF/WeaselTSF.cpp
@@ -176,7 +176,8 @@ STDMETHODIMP WeaselTSF::OnSetThreadFocus() {
   _isToOpenClose = (_ToggleImeOnOpenClose == L"yes");
   if (m_client.Echo()) {
     m_client.ProcessKeyEvent(0);
-    weasel::ResponseParser parser(NULL, NULL, &_status, NULL, &_cand->style());
+    weasel::ResponseParser parser(NULL, NULL, &_status, &_config,
+                                  &_cand->style());
     bool ok = m_client.GetResponseData(std::ref(parser));
     if (ok)
       _UpdateLanguageBar(_status);
@@ -226,7 +227,8 @@ void WeaselTSF::_Reconnect() {
   m_client.Disconnect();
   m_client.Connect(NULL);
   m_client.StartSession();
-  weasel::ResponseParser parser(NULL, NULL, &_status, NULL, &_cand->style());
+  weasel::ResponseParser parser(NULL, NULL, &_status, &_config,
+                                &_cand->style());
   bool ok = m_client.GetResponseData(std::ref(parser));
   if (ok) {
     _UpdateLanguageBar(_status);

--- a/WeaselTSF/WeaselTSF.h
+++ b/WeaselTSF/WeaselTSF.h
@@ -181,6 +181,8 @@ class WeaselTSF : public ITfTextInputProcessorEx,
   void _EnableLanguageBar(BOOL enable);
 
   BOOL _InsertText(com_ptr<ITfContext> pContext, const std::wstring& ext);
+  BOOL _InsertTextAtSelection(com_ptr<ITfContext> pContext,
+                              const std::wstring& text);
 
   void _DeleteCandidateList();
 
@@ -227,10 +229,12 @@ class WeaselTSF : public ITfTextInputProcessorEx,
 
   /* IME status */
   weasel::Status _status;
+  weasel::Config _config;
 
   // guidatom for the display attibute.
   TfGuidAtom _gaDisplayAttributeInput;
   BOOL _async_edit = false;
   BOOL _committed = false;
+  std::wstring _pendingAsciiText;
   BOOL _isToOpenClose = false;
 };

--- a/include/KeyEvent.h
+++ b/include/KeyEvent.h
@@ -30,7 +30,11 @@ struct KeyEvent {
 bool ConvertKeyEvent(UINT vkey,
                      KeyInfo kinfo,
                      const LPBYTE keyState,
+                     LPCWSTR keyboardLayout,
                      weasel::KeyEvent& result);
+
+// Remap a physical key position to the virtual key produced by a named layout.
+UINT RemapKeyByLayout(UINT vkey, UINT scanCode, LPCWSTR layout);
 
 namespace ibus {
 // keycodes

--- a/include/RimeWithWeasel.h
+++ b/include/RimeWithWeasel.h
@@ -118,6 +118,7 @@ class RimeWithWeaselHandler : public weasel::RequestHandler {
   SessionStatusMap m_session_status_map;
   bool m_current_dark_mode;
   bool m_global_ascii_mode;
+  std::string m_keyboard_layout;
   int m_show_notifications_time;
   DWORD m_pid;
 };

--- a/include/WeaselIPCData.h
+++ b/include/WeaselIPCData.h
@@ -187,9 +187,13 @@ struct Status {
 
 // 用於向前端告知設置信息
 struct Config {
-  Config() : inline_preedit(false) {}
-  void reset() { inline_preedit = false; }
+  Config() : inline_preedit(false), keyboard_layout(L"qwerty") {}
+  void reset() {
+    inline_preedit = false;
+    keyboard_layout = L"qwerty";
+  }
   bool inline_preedit;
+  std::wstring keyboard_layout;
 };
 
 struct UIStyle {

--- a/test/TestKeyEventLayout.cpp
+++ b/test/TestKeyEventLayout.cpp
@@ -1,0 +1,63 @@
+#include <Windows.h>
+
+#include <KeyEvent.h>
+
+#include <cassert>
+
+int main() {
+  struct Mapping {
+    UINT scan_code;
+    UINT expected;
+  };
+  const Mapping colemak[] = {
+      {0x12, 'F'}, {0x13, 'P'}, {0x14, 'G'}, {0x15, 'J'},
+      {0x16, 'L'}, {0x17, 'U'}, {0x18, 'Y'}, {0x19, VK_OEM_1},
+      {0x1f, 'R'}, {0x20, 'S'}, {0x21, 'T'}, {0x22, 'D'},
+      {0x24, 'N'}, {0x25, 'E'}, {0x26, 'I'}, {0x27, 'O'},
+      {0x31, 'K'},
+  };
+
+  for (const auto& mapping : colemak) {
+    assert(RemapKeyByLayout(0, mapping.scan_code, L"colemak") ==
+           mapping.expected);
+    assert(RemapKeyByLayout(0, mapping.scan_code, L"COLEMAK") ==
+           mapping.expected);
+  }
+
+  assert(RemapKeyByLayout('Q', 0x10, L"colemak") == 'Q');
+  assert(RemapKeyByLayout('E', 0x12, L"") == 'E');
+  assert(RemapKeyByLayout('E', 0x12, nullptr) == 'E');
+  assert(RemapKeyByLayout(VK_LEFT, 0x4b, L"colemak") == VK_LEFT);
+
+  const Mapping dvorak[] = {
+      {0x10, VK_OEM_7},     {0x11, VK_OEM_COMMA}, {0x12, VK_OEM_PERIOD},
+      {0x13, 'P'},          {0x14, 'Y'},          {0x15, 'F'},
+      {0x16, 'G'},          {0x17, 'C'},          {0x18, 'R'},
+      {0x19, 'L'},          {0x1a, VK_OEM_2},     {0x1b, VK_OEM_PLUS},
+      {0x1e, 'A'},          {0x1f, 'O'},          {0x20, 'E'},
+      {0x21, 'U'},          {0x22, 'I'},          {0x23, 'D'},
+      {0x24, 'H'},          {0x25, 'T'},          {0x26, 'N'},
+      {0x27, 'S'},          {0x28, VK_OEM_MINUS}, {0x2c, VK_OEM_1},
+      {0x2d, 'Q'},          {0x2e, 'J'},          {0x2f, 'K'},
+      {0x30, 'X'},          {0x31, 'B'},          {0x32, 'M'},
+      {0x33, 'W'},          {0x34, 'V'},          {0x35, 'Z'},
+  };
+  for (const auto& mapping : dvorak)
+    assert(RemapKeyByLayout(0, mapping.scan_code, L"dvorak") ==
+           mapping.expected);
+
+  const Mapping workman[] = {
+      {0x11, 'D'}, {0x12, 'R'}, {0x13, 'W'}, {0x14, 'B'},
+      {0x15, 'J'}, {0x16, 'F'}, {0x17, 'U'}, {0x18, 'P'},
+      {0x19, VK_OEM_1},         {0x20, 'H'}, {0x21, 'T'},
+      {0x23, 'Y'}, {0x24, 'N'}, {0x25, 'E'}, {0x26, 'O'},
+      {0x27, 'I'}, {0x2e, 'M'}, {0x2f, 'C'}, {0x30, 'V'},
+      {0x31, 'K'}, {0x32, 'L'},
+  };
+  for (const auto& mapping : workman)
+    assert(RemapKeyByLayout(0, mapping.scan_code, L"workman") ==
+           mapping.expected);
+
+  assert(RemapKeyByLayout('E', 0x12, L"qwerty") == 'E');
+  assert(RemapKeyByLayout('E', 0x12, L"unknown") == 'E');
+}

--- a/test/TestResponseParser/TestResponseParser.cpp
+++ b/test/TestResponseParser/TestResponseParser.cpp
@@ -85,11 +85,25 @@ void test_4() {
   BOOST_TEST_EQ(1, c.totalPages);
 }
 
+void test_config() {
+  WCHAR resp[] =
+      L"action=config\n"
+      L"config.inline_preedit=1\n"
+      L"config.keyboard_layout=colemak\n";
+  DWORD len = wcslen(resp);
+  weasel::Config config;
+  weasel::ResponseParser parser(nullptr, nullptr, nullptr, &config);
+  parser(resp, len);
+  BOOST_TEST(config.inline_preedit);
+  BOOST_TEST(config.keyboard_layout == L"colemak");
+}
+
 int _tmain(int argc, _TCHAR* argv[]) {
   test_1();
   test_2();
   test_3();
   test_4();
+  test_config();
 
   system("pause");
   return boost::report_errors();


### PR DESCRIPTION
## What changed

- Add a global `keyboard_layout` setting to the merged Weasel configuration.
- Support `qwerty` (default), `colemak`, `dvorak`, and `workman`.
- Remap physical scan-code positions before translating key events.
- Apply the configured layout consistently during Rime composition and in ASCII mode while leaving shortcuts untouched.
- Add focused keyboard-mapping and response-parser coverage.

Example configuration in `weasel.custom.yaml`:

```yaml
patch:
  keyboard_layout: colemak
```

## Why

Windows TSF presents QWERTY-oriented key events to IMEs even when the user types with an alternative physical layout. Fixing that system-wide commonly requires registry changes. In contrast, Rime frontends on macOS and Linux generally receive input after the system keyboard layout has been applied.

Without Weasel-side translation, alternative-layout users get QWERTY input in Rime. Passing remapped keys back to the application in ASCII mode also restores Windows' QWERTY interpretation, causing the effective layout to change when switching language modes.

This change keeps the selected layout coherent across Chinese composition and direct English input without requiring system registry changes.

## Validation

- Focused keyboard-layout mapping test passes.
- Release builds completed for x86, x64, and ARM64.
- Built installer tested manually with Colemak in both composition and ASCII modes.
- Verified Shift/Caps behavior and preservation of modified application shortcuts in the implementation path.

Assisted-By: Codex GPT 5.6 Sol