### PR TITLE
fix(WeaselTSF): preserve composition workaround text

### DIFF
--- a/WeaselTSF/Composition.cpp
+++ b/WeaselTSF/Composition.cpp
@@ -51,8 +51,8 @@ STDAPI CStartCompositionEditSession::DoEditSession(TfEditCookie ec) {
      * here. The workaround is only needed when inline preedit is not enabled.
      *   See https://github.com/rime/weasel/pull/883#issuecomment-1567625762
      */
-    if (!_inlinePreeditEnabled) {
-      pRangeComposition->SetText(ec, TF_ST_CORRECTION, L" ", 1);
+    if (_fCUASWorkaroundEnabled && !_inlinePreeditEnabled) {
+      pRangeComposition->SetText(ec, TF_ST_CORRECTION, L"\u2060", 1);
     }
 
     /* set selection */


### PR DESCRIPTION
## 概述
当inline_preedit设置为false时，在例如Telegram Web等网页中无法弹出候选框，需要输入框非空才可以弹出候选框。（见issue #1579 ）
## 问题原因
这是由于小狼毫输入法在启动CUAS定位候选框时向输入框中插入了空格字符，而telegram web将空格视为空内容并执行replaceChildren()，导致composition结束造成的。
将空格替换为U+200B（普通零宽空格）并不能修复该问题，因为零宽空格在chromium TSF管线下会被格式化为空格，导致网页接收到的内容实际上还是空格，因此我将其改为了U+2060（WORD JOINER），不会被chromium TSF格式化，更不会被trim()视为空白，暂未发现副作用（希望没有吧...）。
<img width="2678" height="330" alt="image" src="https://github.com/user-attachments/assets/2f5586c0-5ba4-4531-9133-e233d72282f4" />
同时注意到_fCUASWorkaroundEnabled虽然传入CStartCompositionEditSession但并未参与判断，已增加判断条件，暂未发现副作用。