### PR TITLE
fix: define version macros for C++ builds

### DIFF
--- a/weasel.props.template
+++ b/weasel.props.template
@@ -21,6 +21,7 @@
   </ItemGroup>
   <ItemDefinitionGroup>
     <ClCompile>
+      <PreprocessorDefinitions>VERSION_MAJOR=$(VERSION_MAJOR);VERSION_MINOR=$(VERSION_MINOR);VERSION_PATCH=$(VERSION_PATCH);PRODUCT_VERSION=$(PRODUCT_VERSION);FILE_VERSION=$(FILE_VERSION);%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalOptions>/utf-8</AdditionalOptions>
     </ClCompile>
     <ResourceCompile>

--- a/xmake.lua
+++ b/xmake.lua
@@ -8,6 +8,11 @@ set_runtimes("MT")  -- 设置运行时库为静态链接，避免/MD与/MT冲突
 add_defines("UNICODE", "_UNICODE")
 add_defines("WINDOWS")
 add_defines("MSVC")
+add_defines(
+  "VERSION_MAJOR=" .. (os.getenv("VERSION_MAJOR") or "0"),
+  "VERSION_MINOR=" .. (os.getenv("VERSION_MINOR") or "0"),
+  "VERSION_PATCH=" .. (os.getenv("VERSION_PATCH") or "0")
+)
 
 add_includedirs("$(projectdir)/include")
 -- 设置Boost库的全局路径


### PR DESCRIPTION
 VERSION_*  只传给了 Resource Compiler，没有传给 C++ 编译器；因此  WEASEL_VERSION  被字符串化为字面量  VERSION_MAJOR.VERSION_MINOR.VERSION_PATCH

这会导致C++代码中的宏回退成字面量，影响部署产物中的对应记录回退成字面量