### PR TITLE
fix(WeaselIPC, WeaselServer): 客戶端 IPC 改為有界等待，托盤刷新移至專用執行緒（#1909 後續）

### DIFF
--- a/RimeWithWeasel/RimeWithWeasel.cpp
+++ b/RimeWithWeasel/RimeWithWeasel.cpp
@@ -72,17 +72,10 @@ void _LoadAppOptions(RimeConfig* config, AppOptionsByAppName& app_options);
 
 void _RefreshTrayIcon(const RimeSessionId session_id,
                       const std::function<void()> _UpdateUICallback) {
-  // Dangerous, don't touch
-  static char app_name[256] = {0};
-  auto ret = rime_api->get_property(session_id, "client_app", app_name,
-                                    sizeof(app_name) - 1);
-  if (!ret || u8tow(app_name) == std::wstring(L"explorer.exe"))
-    boost::thread th([=]() {
-      ::Sleep(100);
-      if (_UpdateUICallback)
-        _UpdateUICallback();
-    });
-  else if (_UpdateUICallback)
+  // the callback only hands a state snapshot to the tray thread,
+  // so it is safe to invoke synchronously for every client, explorer.exe
+  // included
+  if (_UpdateUICallback)
     _UpdateUICallback();
 }
 

--- a/WeaselIPC/PipeChannel.cpp
+++ b/WeaselIPC/PipeChannel.cpp
@@ -18,7 +18,11 @@ using namespace boost;
 namespace {
 struct OverlappedOp {
   OVERLAPPED ov;
-  OverlappedOp() : ov() { ov.hEvent = ::CreateEvent(NULL, TRUE, FALSE, NULL); }
+  OverlappedOp() : ov() {
+    ov.hEvent = ::CreateEvent(NULL, TRUE, FALSE, NULL);
+    if (!ov.hEvent)
+      _ThrowLastError;
+  }
   ~OverlappedOp() {
     if (ov.hEvent)
       ::CloseHandle(ov.hEvent);
@@ -95,10 +99,14 @@ DWORD PipeChannelBase::_WaitIo(HANDLE pipe,
   }
   DWORD wait = ::WaitForSingleObject(ov.hEvent, timeout_ms);
   if (wait != WAIT_OBJECT_0) {
+    DWORD wait_err = wait == WAIT_TIMEOUT ? static_cast<DWORD>(ERROR_TIMEOUT)
+                                          : ::GetLastError();
+    // the OVERLAPPED lives on the caller's stack, so the I/O must be complete
+    // before returning; CancelIoEx fails only when the I/O already completed
+    // (ERROR_NOT_FOUND), in which case the event is already signaled
     ::CancelIoEx(pipe, &ov);
     ::WaitForSingleObject(ov.hEvent, INFINITE);
-    _ThrowCode(wait == WAIT_TIMEOUT ? static_cast<DWORD>(ERROR_TIMEOUT)
-                                    : ::GetLastError());
+    _ThrowCode(wait_err);
   }
   DWORD n = 0;
   if (!::GetOverlappedResult(pipe, &ov, &n, FALSE)) {
@@ -141,22 +149,32 @@ void PipeChannelBase::_Receive(HANDLE pipe,
                                LPVOID msg,
                                size_t rec_len,
                                DWORD timeout_ms) {
-  DWORD err;
-  {
-    OverlappedOp op;
-    BOOL success =
-        ::ReadFile(pipe, msg, static_cast<DWORD>(rec_len), NULL, &op.ov);
-    err = _WaitIo(pipe, op.ov, success, timeout_ms, NULL);
-  }
-  if (err == ERROR_MORE_DATA) {
-    auto ctx = _GetContext();
-    memset(ctx->buffer.get(), 0, buff_size);
-    OverlappedOp op;
-    BOOL success = ::ReadFile(pipe, ctx->buffer.get(),
-                              static_cast<DWORD>(buff_size), NULL, &op.ov);
-    err = _WaitIo(pipe, op.ov, success, timeout_ms, NULL);
-    if (err != ERROR_SUCCESS)
-      _ThrowCode(err);
+  try {
+    DWORD err;
+    {
+      OverlappedOp op;
+      BOOL success =
+          ::ReadFile(pipe, msg, static_cast<DWORD>(rec_len), NULL, &op.ov);
+      err = _WaitIo(pipe, op.ov, success, timeout_ms, NULL);
+    }
+    if (err == ERROR_MORE_DATA) {
+      auto ctx = _GetContext();
+      memset(ctx->buffer.get(), 0, buff_size);
+      OverlappedOp op;
+      BOOL success = ::ReadFile(pipe, ctx->buffer.get(),
+                                static_cast<DWORD>(buff_size), NULL, &op.ov);
+      err = _WaitIo(pipe, op.ov, success, timeout_ms, NULL);
+      if (err != ERROR_SUCCESS)
+        _ThrowCode(err);
+    }
+  } catch (...) {
+    // a response that was abandoned (timed out / cancelled) would otherwise
+    // arrive as the reply to the next request on this pipe, so drop the
+    // client's connection; the next transaction reconnects
+    HANDLE* phandle = _GetPipeHandle();
+    if (*phandle == pipe)
+      _FinalizePipe(*phandle);
+    throw;
   }
   _GetContext()->has_body = false;
 }
@@ -173,7 +191,12 @@ HANDLE PipeChannelBase::_ConnectServerPipe(std::wstring& pn) {
   BOOL ok = ::ConnectNamedPipe(pipe, &op.ov);
   DWORD err = ok ? ERROR_SUCCESS : ::GetLastError();
   if (!ok && err == ERROR_IO_PENDING) {
-    ::WaitForSingleObject(op.ov.hEvent, INFINITE);
+    if (::WaitForSingleObject(op.ov.hEvent, INFINITE) != WAIT_OBJECT_0) {
+      err = ::GetLastError();
+      ::CancelIoEx(pipe, &op.ov);
+      ::CloseHandle(pipe);
+      _ThrowCode(err);
+    }
     DWORD n = 0;
     if (!::GetOverlappedResult(pipe, &op.ov, &n, FALSE)) {
       err = ::GetLastError();

--- a/WeaselIPC/PipeChannel.cpp
+++ b/WeaselIPC/PipeChannel.cpp
@@ -15,6 +15,17 @@ using namespace boost;
       throw err;                         \
   }
 
+namespace {
+struct OverlappedOp {
+  OVERLAPPED ov;
+  OverlappedOp() : ov() { ov.hEvent = ::CreateEvent(NULL, TRUE, FALSE, NULL); }
+  ~OverlappedOp() {
+    if (ov.hEvent)
+      ::CloseHandle(ov.hEvent);
+  }
+};
+}  // namespace
+
 PipeChannelBase::PipeChannelBase(std::wstring&& pn_cmd,
                                  size_t bs = 4 * 1024,
                                  SECURITY_ATTRIBUTES* s = NULL)
@@ -28,7 +39,7 @@ bool PipeChannelBase::_Ensure() {
   try {
     HANDLE* phandle = _GetPipeHandle();
     if (_Invalid(*phandle)) {
-      *phandle = _Connect(pname.c_str());
+      *phandle = _Connect();
       return !_Invalid(*phandle);
     }
   } catch (...) {
@@ -38,10 +49,12 @@ bool PipeChannelBase::_Ensure() {
   return true;
 }
 
-HANDLE PipeChannelBase::_Connect(const wchar_t* name) {
-  HANDLE pipe = INVALID_HANDLE_VALUE;
-  while (_Invalid(pipe = _TryConnect()))
-    ::WaitNamedPipe(name, 500);
+HANDLE PipeChannelBase::_Connect() {
+  // fail fast when all instances are busy: this runs on the host app's UI
+  // thread, which must never wait for the server
+  HANDLE pipe = _TryConnect();
+  if (_Invalid(pipe))
+    _ThrowCode(static_cast<DWORD>(ERROR_PIPE_BUSY));
   DWORD mode = PIPE_READMODE_MESSAGE;
   if (!SetNamedPipeHandleState(pipe, &mode, NULL, NULL)) {
     _ThrowLastError;
@@ -57,7 +70,7 @@ void PipeChannelBase::_Reconnect() {
 
 HANDLE PipeChannelBase::_TryConnect() {
   auto pipe = ::CreateFile(pname.c_str(), GENERIC_READ | GENERIC_WRITE, 0, NULL,
-                           OPEN_EXISTING, 0, NULL);
+                           OPEN_EXISTING, FILE_FLAG_OVERLAPPED, NULL);
   if (!_Invalid(pipe)) {
     // connected to the pipe
     return pipe;
@@ -68,12 +81,51 @@ HANDLE PipeChannelBase::_TryConnect() {
   return INVALID_HANDLE_VALUE;
 }
 
-size_t PipeChannelBase::_WritePipe(HANDLE pipe, size_t s, char* b) {
-  DWORD lwritten;
-  if (!::WriteFile(pipe, b, s, &lwritten, NULL) || lwritten <= 0) {
-    _ThrowLastError;
+DWORD PipeChannelBase::_WaitIo(HANDLE pipe,
+                               OVERLAPPED& ov,
+                               BOOL op_result,
+                               DWORD timeout_ms,
+                               DWORD* transferred) {
+  if (!op_result) {
+    DWORD err = ::GetLastError();
+    if (err == ERROR_MORE_DATA)
+      return ERROR_MORE_DATA;
+    if (err != ERROR_IO_PENDING)
+      _ThrowCode(err);
   }
-  ::FlushFileBuffers(pipe);
+  DWORD wait = ::WaitForSingleObject(ov.hEvent, timeout_ms);
+  if (wait != WAIT_OBJECT_0) {
+    ::CancelIoEx(pipe, &ov);
+    ::WaitForSingleObject(ov.hEvent, INFINITE);
+    _ThrowCode(wait == WAIT_TIMEOUT ? static_cast<DWORD>(ERROR_TIMEOUT)
+                                    : ::GetLastError());
+  }
+  DWORD n = 0;
+  if (!::GetOverlappedResult(pipe, &ov, &n, FALSE)) {
+    DWORD err = ::GetLastError();
+    if (transferred)
+      *transferred = n;
+    if (err == ERROR_MORE_DATA)
+      return ERROR_MORE_DATA;
+    _ThrowCode(err);
+  }
+  if (transferred)
+    *transferred = n;
+  return ERROR_SUCCESS;
+}
+
+size_t PipeChannelBase::_WritePipe(HANDLE pipe,
+                                   size_t s,
+                                   char* b,
+                                   DWORD timeout_ms) {
+  OverlappedOp op;
+  BOOL success = ::WriteFile(pipe, b, static_cast<DWORD>(s), NULL, &op.ov);
+  DWORD lwritten = 0;
+  DWORD err = _WaitIo(pipe, op.ov, success, timeout_ms, &lwritten);
+  if (err != ERROR_SUCCESS || lwritten == 0) {
+    _ThrowCode(err != ERROR_SUCCESS ? err
+                                    : static_cast<DWORD>(ERROR_WRITE_FAULT));
+  }
   return lwritten;
 }
 
@@ -85,29 +137,52 @@ void PipeChannelBase::_FinalizePipe(HANDLE& p) {
   p = INVALID_HANDLE_VALUE;
 }
 
-void PipeChannelBase::_Receive(HANDLE pipe, LPVOID msg, size_t rec_len) {
-  DWORD lread;
-  BOOL success = ::ReadFile(pipe, msg, rec_len, &lread, NULL);
-  if (!success) {
-    _ThrowIfNot(ERROR_MORE_DATA);
-
+void PipeChannelBase::_Receive(HANDLE pipe,
+                               LPVOID msg,
+                               size_t rec_len,
+                               DWORD timeout_ms) {
+  DWORD err;
+  {
+    OverlappedOp op;
+    BOOL success =
+        ::ReadFile(pipe, msg, static_cast<DWORD>(rec_len), NULL, &op.ov);
+    err = _WaitIo(pipe, op.ov, success, timeout_ms, NULL);
+  }
+  if (err == ERROR_MORE_DATA) {
     auto ctx = _GetContext();
     memset(ctx->buffer.get(), 0, buff_size);
-    success = ::ReadFile(pipe, ctx->buffer.get(), buff_size, &lread, NULL);
-    if (!success) {
-      _ThrowLastError;
-    }
+    OverlappedOp op;
+    BOOL success = ::ReadFile(pipe, ctx->buffer.get(),
+                              static_cast<DWORD>(buff_size), NULL, &op.ov);
+    err = _WaitIo(pipe, op.ov, success, timeout_ms, NULL);
+    if (err != ERROR_SUCCESS)
+      _ThrowCode(err);
   }
   _GetContext()->has_body = false;
 }
 
 HANDLE PipeChannelBase::_ConnectServerPipe(std::wstring& pn) {
   HANDLE pipe =
-      CreateNamedPipe(pn.c_str(), PIPE_ACCESS_DUPLEX,
+      CreateNamedPipe(pn.c_str(), PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED,
                       PIPE_TYPE_MESSAGE | PIPE_READMODE_MESSAGE | PIPE_WAIT,
                       PIPE_UNLIMITED_INSTANCES, buff_size, buff_size, 0, sa);
-  if (pipe == INVALID_HANDLE_VALUE || !::ConnectNamedPipe(pipe, NULL)) {
+  if (pipe == INVALID_HANDLE_VALUE) {
     _ThrowLastError;
+  }
+  OverlappedOp op;
+  BOOL ok = ::ConnectNamedPipe(pipe, &op.ov);
+  DWORD err = ok ? ERROR_SUCCESS : ::GetLastError();
+  if (!ok && err == ERROR_IO_PENDING) {
+    ::WaitForSingleObject(op.ov.hEvent, INFINITE);
+    DWORD n = 0;
+    if (!::GetOverlappedResult(pipe, &op.ov, &n, FALSE)) {
+      err = ::GetLastError();
+      ::CloseHandle(pipe);
+      _ThrowCode(err);
+    }
+  } else if (!ok && err != ERROR_PIPE_CONNECTED) {
+    ::CloseHandle(pipe);
+    _ThrowCode(err);
   }
   return pipe;
 }

--- a/WeaselIPC/WeaselClientImpl.cpp
+++ b/WeaselIPC/WeaselClientImpl.cpp
@@ -190,12 +190,40 @@ bool ClientImpl::_WriteClientInfo() {
   return true;
 }
 
+namespace {
+// Focus / notification commands:
+// a miss self-heals on the next event, so cap them tightly to keep window
+// switching imperceptible. Compose / keystroke commands need a reliable answer,
+// so keep the larger cap.
+DWORD _TimeoutForCommand(WEASEL_IPC_COMMAND msg, DWORD wParam) {
+  switch (msg) {
+    case WEASEL_IPC_ECHO:
+    case WEASEL_IPC_FOCUS_IN:
+    case WEASEL_IPC_FOCUS_OUT:
+    case WEASEL_IPC_START_SESSION:
+    case WEASEL_IPC_END_SESSION:
+    case WEASEL_IPC_START_MAINTENANCE:
+    case WEASEL_IPC_END_MAINTENANCE:
+    case WEASEL_IPC_UPDATE_INPUT_POS:
+    case WEASEL_IPC_TRAY_COMMAND:
+      return PipeChannelBase::kClientFocusTimeoutMs;
+    case WEASEL_IPC_PROCESS_KEY_EVENT:
+      // keycode 0 is the focus-refresh probe from OnSetThreadFocus, not a real
+      // keystroke; keep real keys on the reliable compose-path cap
+      return wParam == 0 ? PipeChannelBase::kClientFocusTimeoutMs
+                         : PipeChannelBase::kClientIoTimeoutMs;
+    default:
+      return PipeChannelBase::kClientIoTimeoutMs;
+  }
+}
+}  // namespace
+
 LRESULT ClientImpl::_SendMessage(WEASEL_IPC_COMMAND Msg,
                                  DWORD wParam,
                                  DWORD lParam) {
   try {
     PipeMessage req{Msg, wParam, lParam};
-    return channel.Transact(req);
+    return channel.Transact(req, _TimeoutForCommand(Msg, wParam));
   } catch (DWORD /* ex */) {
     return 0;
   }

--- a/WeaselIPCServer/WeaselServerImpl.cpp
+++ b/WeaselIPCServer/WeaselServerImpl.cpp
@@ -131,19 +131,6 @@ LRESULT ServerImpl::OnCommand(UINT uMsg,
   return 0;
 }
 
-LRESULT ServerImpl::OnServiceNotifyMessage(UINT uMsg,
-                                           WPARAM wParam,
-                                           LPARAM lParam,
-                                           BOOL& bHandled) {
-  // Runs on the server message thread, NOT on a pipe worker thread and
-  // without holding g_api_mutex, so that Shell_NotifyIcon inside the tray
-  // update can never deadlock against the taskbar UI thread.
-  if (m_trayRefreshCallback) {
-    m_trayRefreshCallback();
-  }
-  return 0;
-}
-
 DWORD ServerImpl::OnCommand(WEASEL_IPC_COMMAND uMsg,
                             DWORD wParam,
                             DWORD lParam) {
@@ -477,10 +464,6 @@ void Server::SetRequestHandler(RequestHandler* pHandler) {
 
 void Server::AddMenuHandler(UINT uID, CommandHandler handler) {
   m_pImpl->AddMenuHandler(uID, handler);
-}
-
-void Server::SetTrayRefreshCallback(std::function<void()> callback) {
-  m_pImpl->SetTrayRefreshCallback(callback);
 }
 
 HWND Server::GetHWnd() {

--- a/WeaselIPCServer/WeaselServerImpl.h
+++ b/WeaselIPCServer/WeaselServerImpl.h
@@ -28,7 +28,6 @@ class ServerImpl : public CWindowImpl<ServerImpl, CWindow, ServerWinTraits>
   MESSAGE_HANDLER(WM_DWMCOLORIZATIONCOLORCHANGED, OnColorChange)
   MESSAGE_HANDLER(WM_SETTINGCHANGE, OnColorChange)
   MESSAGE_HANDLER(WM_COMMAND, OnCommand)
-  MESSAGE_HANDLER(WM_WEASEL_SERVICE_NOTIFY, OnServiceNotifyMessage)
   END_MSG_MAP()
 
   LRESULT OnColorChange(UINT uMsg,
@@ -47,10 +46,6 @@ class ServerImpl : public CWindowImpl<ServerImpl, CWindow, ServerWinTraits>
                              LPARAM lParam,
                              BOOL& bHandled);
   LRESULT OnCommand(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
-  LRESULT OnServiceNotifyMessage(UINT uMsg,
-                                 WPARAM wParam,
-                                 LPARAM lParam,
-                                 BOOL& bHandled);
   DWORD OnCommand(WEASEL_IPC_COMMAND uMsg, DWORD wParam, DWORD lParam);
   DWORD OnEcho(WEASEL_IPC_COMMAND uMsg, DWORD wParam, DWORD lParam);
   DWORD OnStartSession(WEASEL_IPC_COMMAND uMsg, DWORD wParam, DWORD lParam);
@@ -90,9 +85,6 @@ class ServerImpl : public CWindowImpl<ServerImpl, CWindow, ServerWinTraits>
   void AddMenuHandler(UINT uID, CommandHandler& handler) {
     m_MenuHandlers[uID] = handler;
   }
-  void SetTrayRefreshCallback(std::function<void()> callback) {
-    m_trayRefreshCallback = callback;
-  }
 
  private:
   void _Finailize();
@@ -103,7 +95,6 @@ class ServerImpl : public CWindowImpl<ServerImpl, CWindow, ServerWinTraits>
   std::unique_ptr<boost::thread> pipeThread;
   RequestHandler* m_pRequestHandler;  // reference
   std::map<UINT, CommandHandler> m_MenuHandlers;
-  std::function<void()> m_trayRefreshCallback;
   HMODULE m_hUser32Module;
   SecurityAttribute sa;
   BOOL m_darkMode;

--- a/WeaselServer/SystemTraySDK.h
+++ b/WeaselServer/SystemTraySDK.h
@@ -145,7 +145,7 @@ public:
 // Implementation
 protected:
     void Initialise();
-    void InstallIconPending();
+    virtual void InstallIconPending();
     ATOM RegisterClass(HINSTANCE hInstance);
 
     virtual void CustomizeMenu(HMENU) {}

--- a/WeaselServer/WeaselServerApp.cpp
+++ b/WeaselServer/WeaselServerApp.cpp
@@ -33,7 +33,6 @@ int WeaselServerApp::Run() {
   m_handler->OnUpdateUI([this]() { tray_icon.RequestRefresh(); });
 
   tray_icon.Create(m_server.GetHWnd());
-  m_server.SetTrayRefreshCallback([this]() { tray_icon.ApplyRefresh(); });
   tray_icon.RequestRefresh();
 
   int ret = m_server.Run();

--- a/WeaselServer/WeaselTrayIcon.cpp
+++ b/WeaselServer/WeaselTrayIcon.cpp
@@ -23,6 +23,16 @@ WeaselTrayIcon::~WeaselTrayIcon() {
 
 void WeaselTrayIcon::CustomizeMenu(HMENU hMenu) {}
 
+LRESULT WeaselTrayIcon::OnTrayNotification(WPARAM uID, LPARAM lEvent) {
+  std::lock_guard<std::recursive_mutex> lock(m_tray_mutex);
+  return CSystemTray::OnTrayNotification(uID, lEvent);
+}
+
+void WeaselTrayIcon::InstallIconPending() {
+  std::lock_guard<std::recursive_mutex> lock(m_tray_mutex);
+  CSystemTray::InstallIconPending();
+}
+
 BOOL WeaselTrayIcon::Create(HWND hTargetWnd) {
   HMODULE hModule = GetModuleHandle(NULL);
   CIcon icon;
@@ -83,6 +93,7 @@ void WeaselTrayIcon::DisableRefresh() {
 }
 
 void WeaselTrayIcon::Refresh(const WeaselTrayIconState& state) {
+  std::lock_guard<std::recursive_mutex> lock(m_tray_mutex);
   if (!state.display_tray_icon &&
       !state.disabled)  // display notification when deploying
   {

--- a/WeaselServer/WeaselTrayIcon.cpp
+++ b/WeaselServer/WeaselTrayIcon.cpp
@@ -17,6 +17,10 @@ WeaselTrayIcon::WeaselTrayIcon(weasel::UI& ui)
       m_schema_ascii_icon(),
       m_disabled(false) {}
 
+WeaselTrayIcon::~WeaselTrayIcon() {
+  DisableRefresh();
+}
+
 void WeaselTrayIcon::CustomizeMenu(HMENU hMenu) {}
 
 BOOL WeaselTrayIcon::Create(HWND hTargetWnd) {
@@ -34,6 +38,7 @@ BOOL WeaselTrayIcon::Create(HWND hTargetWnd) {
   } else {
     AddIcon();
   }
+  m_refresh_thread = std::thread([this] { RefreshThreadProc(); });
   return bRet;
 }
 
@@ -43,39 +48,38 @@ void WeaselTrayIcon::RequestRefresh() {
     return;
   }
   m_pending_state = WeaselTrayIconState::From(m_style, m_status);
-  if (m_refresh_pending) {
-    return;
-  }
   m_refresh_pending = true;
-  if (!::PostMessage(GetTargetWnd(), WM_WEASEL_SERVICE_NOTIFY, 0, 0)) {
-    m_refresh_pending = false;
-  }
+  m_state_cv.notify_one();
 }
 
-void WeaselTrayIcon::ApplyRefresh() {
-  WeaselTrayIconState state;
-  {
-    std::lock_guard<std::mutex> lock(m_state_mutex);
-    if (!m_refresh_pending || !m_refresh_enabled) {
-      return;
+// Pending requests are coalesced: only the latest snapshot is applied.
+void WeaselTrayIcon::RefreshThreadProc() {
+  for (;;) {
+    WeaselTrayIconState state;
+    {
+      std::unique_lock<std::mutex> lock(m_state_mutex);
+      m_state_cv.wait(
+          lock, [this] { return m_refresh_pending || !m_refresh_enabled; });
+      if (!m_refresh_enabled) {
+        return;
+      }
+      state = m_pending_state;
+      m_refresh_pending = false;
     }
-    state = m_pending_state;
-    m_refresh_pending = false;
-    m_refresh_in_progress = true;
+    Refresh(state);
   }
-  Refresh(state);
-  {
-    std::lock_guard<std::mutex> lock(m_state_mutex);
-    m_refresh_in_progress = false;
-  }
-  m_state_cv.notify_all();
 }
 
 void WeaselTrayIcon::DisableRefresh() {
-  std::unique_lock<std::mutex> lock(m_state_mutex);
-  m_refresh_enabled = false;
-  m_refresh_pending = false;
-  m_state_cv.wait(lock, [this] { return !m_refresh_in_progress; });
+  {
+    std::lock_guard<std::mutex> lock(m_state_mutex);
+    m_refresh_enabled = false;
+    m_refresh_pending = false;
+  }
+  m_state_cv.notify_all();
+  if (m_refresh_thread.joinable()) {
+    m_refresh_thread.join();
+  }
 }
 
 void WeaselTrayIcon::Refresh(const WeaselTrayIconState& state) {

--- a/WeaselServer/WeaselTrayIcon.h
+++ b/WeaselServer/WeaselTrayIcon.h
@@ -79,6 +79,13 @@ class WeaselTrayIcon : public CSystemTray {
  protected:
   virtual void CustomizeMenu(HMENU hMenu);
 
+  // CSystemTray state is touched from the tray thread (Refresh) and from the
+  // server message thread (tray notifications, taskbar re-creation); every
+  // entry point takes m_tray_mutex. Recursive because a tray menu's modal
+  // loop may dispatch a taskbar re-creation while the lock is held.
+  virtual LRESULT OnTrayNotification(WPARAM uID, LPARAM lEvent) override;
+  virtual void InstallIconPending() override;
+
   void Refresh(const WeaselTrayIconState& state);
   void RefreshThreadProc();
 
@@ -96,4 +103,5 @@ class WeaselTrayIcon : public CSystemTray {
   std::mutex m_state_mutex;
   std::condition_variable m_state_cv;
   std::thread m_refresh_thread;
+  std::recursive_mutex m_tray_mutex;
 };

--- a/WeaselServer/WeaselTrayIcon.h
+++ b/WeaselServer/WeaselTrayIcon.h
@@ -5,14 +5,18 @@
 
 #include <condition_variable>
 #include <mutex>
+#include <thread>
 
 #define WM_WEASEL_TRAY_NOTIFY (WEASEL_IPC_LAST_COMMAND + 100)
 
 // Snapshot of the tray-relevant UI state, computed on the pipe worker thread
-// and applied on the server message thread. Keeps Shell_NotifyIcon off the
-// pipe worker threads (and away from g_api_mutex), avoiding the deadlock loop
-// where the taskbar UI thread waits on the pipe while the server waits for the
-// taskbar UI thread inside Shell_NotifyIcon.
+// and applied on a dedicated tray thread. Keeps Shell_NotifyIcon off the pipe
+// worker threads (and away from g_api_mutex) and off the server message thread:
+// Shell_NotifyIcon waits on the taskbar UI thread with SMTO_BLOCK,
+// and while the taskbar UI thread itself is waiting on the pipe,
+// a pipe worker doing a cross-thread SetWindowPos/ShowWindow on the candidate
+// window would otherwise wait on the blocked message thread, closing the
+// deadlock loop.
 struct WeaselTrayIconState {
   WeaselTrayIconState()
       : valid(false),
@@ -61,21 +65,22 @@ class WeaselTrayIcon : public CSystemTray {
   };
 
   WeaselTrayIcon(weasel::UI& ui);
+  ~WeaselTrayIcon();
 
   BOOL Create(HWND hTargetWnd);
 
-  // Captures the tray-relevant state and posts a refresh request to the server
-  // message thread. Never calls Shell_NotifyIcon itself.
+  // Captures the tray-relevant state and wakes the tray thread.
+  // Never calls Shell_NotifyIcon itself, so it is safe from any thread and
+  // under any lock.
   void RequestRefresh();
+  // Stops the tray thread; waits for an in-flight refresh to finish.
   void DisableRefresh();
-
-  // Runs on the server message thread (no g_api_mutex held).
-  void ApplyRefresh();
 
  protected:
   virtual void CustomizeMenu(HMENU hMenu);
 
   void Refresh(const WeaselTrayIconState& state);
+  void RefreshThreadProc();
 
   weasel::UIStyle& m_style;
   weasel::Status& m_status;
@@ -87,8 +92,8 @@ class WeaselTrayIcon : public CSystemTray {
   // Guarded by m_state_mutex.
   bool m_refresh_enabled = true;
   bool m_refresh_pending = false;
-  bool m_refresh_in_progress = false;
   WeaselTrayIconState m_pending_state;
   std::mutex m_state_mutex;
   std::condition_variable m_state_cv;
+  std::thread m_refresh_thread;
 };

--- a/include/PipeChannel.h
+++ b/include/PipeChannel.h
@@ -188,7 +188,8 @@ class PipeChannel : public PipeChannelBase {
       _WritePipe(pipe, data_sz, pbuff, timeout_ms);
     } catch (...) {
       _Reconnect();
-      _WritePipe(pipe, data_sz, pbuff, timeout_ms);
+      // _Reconnect() closed `pipe` and opened a new handle; retry on that one
+      _WritePipe(*_GetPipeHandle(), data_sz, pbuff, timeout_ms);
     }
     ClearBufferStream();
   }

--- a/include/PipeChannel.h
+++ b/include/PipeChannel.h
@@ -24,20 +24,39 @@ class PipeChannelBase {
   PipeChannelBase(std::wstring&& pn_cmd, size_t bs, SECURITY_ATTRIBUTES* s);
   ~PipeChannelBase();
 
+  /* Caps for pipe I/O issued from client (host app) threads.
+     compose/keystroke path keeps a larger cap so a busy server never causes a
+     key to be dropped; focus/notification path uses a tiny cap so window
+     switching stays imperceptible (a missed notification self-heals on the next
+     event). */
+  static const DWORD kClientIoTimeoutMs = 500;
+  static const DWORD kClientFocusTimeoutMs = 25;
+
  protected:
   /* To ensure connection before operation */
   bool _Ensure();
-  /* Connect pipe as client */
-  HANDLE _Connect(const wchar_t* name);
+  /* Connect pipe as client, failing fast when the server is busy */
+  HANDLE _Connect();
   /* To reconnect message pipe */
   void _Reconnect();
   /* Try to connect for one time */
   HANDLE _TryConnect();
-  size_t _WritePipe(HANDLE p, size_t s, char* b);
+  size_t _WritePipe(HANDLE p, size_t s, char* b, DWORD timeout_ms = INFINITE);
   void _FinalizePipe(HANDLE& p);
-  void _Receive(HANDLE pipe, LPVOID msg, size_t rec_len);
+  void _Receive(HANDLE pipe,
+                LPVOID msg,
+                size_t rec_len,
+                DWORD timeout_ms = INFINITE);
   /* Try to get a connection from client */
   HANDLE _ConnectServerPipe(std::wstring& pn);
+  /* Wait for an overlapped I/O with timeout;
+     returns ERROR_SUCCESS or ERROR_MORE_DATA, throws DWORD on failure or
+     timeout */
+  DWORD _WaitIo(HANDLE pipe,
+                OVERLAPPED& ov,
+                BOOL op_result,
+                DWORD timeout_ms,
+                DWORD* transferred = nullptr);
   inline bool _Invalid(HANDLE p) const { return p == INVALID_HANDLE_VALUE; }
 
   HANDLE* _GetPipeHandle() const {
@@ -117,11 +136,11 @@ class PipeChannel : public PipeChannelBase {
     return *this;
   }
 
-  _TyRes Transact(Msg& msg) {
+  _TyRes Transact(Msg& msg, DWORD timeout_ms = kClientIoTimeoutMs) {
     _Ensure();
     HANDLE* phandle = _GetPipeHandle();
-    _Send(*phandle, msg);
-    return _ReceiveResponse();
+    _Send(*phandle, msg, timeout_ms);
+    return _ReceiveResponse(timeout_ms);
   }
 
   void ClearBufferStream() {
@@ -148,7 +167,7 @@ class PipeChannel : public PipeChannelBase {
   }
 
  protected:
-  void _Send(HANDLE pipe, Msg& msg) {
+  void _Send(HANDLE pipe, Msg& msg, DWORD timeout_ms = INFINITE) {
     auto ctx = _GetContext();
     char* pbuff = ctx->buffer.get();
     DWORD lwritten = 0;
@@ -166,18 +185,18 @@ class PipeChannel : public PipeChannelBase {
       data_sz = buff_size;
 
     try {
-      _WritePipe(pipe, data_sz, pbuff);
+      _WritePipe(pipe, data_sz, pbuff, timeout_ms);
     } catch (...) {
       _Reconnect();
-      _WritePipe(pipe, data_sz, pbuff);
+      _WritePipe(pipe, data_sz, pbuff, timeout_ms);
     }
     ClearBufferStream();
   }
 
-  _TyRes _ReceiveResponse() {
+  _TyRes _ReceiveResponse(DWORD timeout_ms = kClientIoTimeoutMs) {
     HANDLE* phandle = _GetPipeHandle();
     _TyRes result;
-    _Receive(*phandle, &result, sizeof(result));
+    _Receive(*phandle, &result, sizeof(result), timeout_ms);
     return result;
   }
 

--- a/include/WeaselIPC.h
+++ b/include/WeaselIPC.h
@@ -35,10 +35,6 @@ enum WEASEL_IPC_COMMAND {
   WEASEL_IPC_LAST_COMMAND
 };
 
-// Posted by WeaselTrayIcon to the server window so that Shell_NotifyIcon runs
-// on the server message thread instead of a pipe worker thread.
-#define WM_WEASEL_SERVICE_NOTIFY (WEASEL_IPC_LAST_COMMAND + 200)
-
 namespace weasel {
 struct PipeMessage {
   WEASEL_IPC_COMMAND Msg;
@@ -166,10 +162,6 @@ class Server {
   void SetRequestHandler(RequestHandler* pHandler);
   void AddMenuHandler(UINT uID, CommandHandler handler);
   HWND GetHWnd();
-
-  // Callback invoked on the server message thread when a tray icon refresh is
-  // requested from a pipe worker thread.
-  void SetTrayRefreshCallback(std::function<void()> callback);
 
  private:
   ServerImpl* m_pImpl;


### PR DESCRIPTION
## 概要

補 #1909 的客戶端那一半，與已合併的 #1912 互補。

#1912 把托盤刷新移到伺服器訊息執行緒，斷開了「explorer 工作列執行緒等管線回應 ↔ WeaselServer 管線工作執行緒等 `Shell_NotifyIcon`」的死結環，解決了最常見的 7～8 秒凍結。
但 `WeaselIPC` 客戶端本身仍是無限等待：TSF 模組載入於每個宿主行程，焦點切換與按鍵的 IPC 往返都跑在宿主 UI 執行緒上，只要伺服器因任何原因停頓，宿主視窗就被一起拖死。
本 PR 讓跑在宿主執行緒上的客戶端 IPC 一律有上限，伺服器端呼叫路徑維持原行為。

## 現況問題（`WeaselIPC/PipeChannel.cpp`）

1. `_Connect()` 以 `while (_Invalid(pipe = _TryConnect())) ::WaitNamedPipe(name, 500);` 無限重試——伺服器忙到掛不出管線執行個體時，宿主 UI 執行緒永遠等下去。
2. `_Receive()`／`_WritePipe()` 用同步 `ReadFile`／`WriteFile`，無逾時；連上之後伺服器不回應即死等（#1909 與 #1878 的傾印都停在這裡的 `WaitForSingleObject(hPipe, INFINITE)`）。
3. `_WritePipe()` 內的 `FlushFileBuffers` 在具名管線上會等到對端讀走才返回，伺服器忙碌時成為額外阻塞點；request/response 模式已有同步點，此呼叫無必要。

#1912 之後仍會觸發上述等待的情境：

- 部署、`SyncUserData`、大型 userdb 寫入等使 `g_api_mutex` 長時間被持有。
- `RimeWithWeaselHandler::FocusIn` → `_UpdateUI()` 仍在管線工作執行緒上呼叫 `m_ui->Hide()`／`m_ui->Update()`；後者在 ctx/status 改變時會走 `WeaselPanel::Refresh()` 的 `SetWindowPos`，而候選視窗屬伺服器訊息執行緒，跨執行緒 `SetWindowPos`／`ShowWindow` 是同步送訊息。若訊息執行緒此刻正在 `Shell_NotifyIcon`（內部 `SendMessageTimeout` 帶 `SMTO_BLOCK`，期間不處理送入訊息），原本的環仍可短暫成立。
- 第三方掛鉤（防毒）包覆管線 I/O 拉長處理時間。

## 修改內容

三個提交，可獨立審閱：

### 1. `WeaselIPC` 客戶端有界等待

全部收斂在 `WeaselIPC`，不動 TSF 端語義：

- `_Connect()` 改為 fail-fast：一次連不上即丟 `ERROR_PIPE_BUSY`，由既有 `_Ensure()` 接住回傳失敗；移除 `WaitNamedPipe` 迴圈。
- 管線以 `FILE_FLAG_OVERLAPPED` 開啟；新增 `_WaitIo()` 對讀寫套 `WaitForSingleObject` 逾時，逾時即 `CancelIoEx` 視同斷線。`ERROR_MORE_DATA` 兩段式讀取語義保留。
- 移除 `_WritePipe()` 的 `FlushFileBuffers`。
- `_ConnectServerPipe()` 配合改用 OVERLAPPED 的 `ConnectNamedPipe`（等待仍為 INFINITE），並修掉失敗路徑的控制代碼洩漏。
- `_WritePipe()`／`_Receive()`／`Transact()` 新增 `timeout_ms` 參數，預設 `INFINITE`，伺服器端呼叫不受影響。
- 客戶端逾時依指令性質分兩級（`WeaselClientImpl.cpp` 的 `_TimeoutForCommand()`）：
  - 組字／按鍵路徑（真實按鍵的 `PROCESS_KEY_EVENT`、`COMMIT`、選字、翻頁等）：`kClientIoTimeoutMs`，確保按鍵不因短暫忙碌被放行。
  - 焦點／通知路徑（`ECHO`、`FOCUS_IN`／`FOCUS_OUT`、`START_SESSION`／`END_SESSION`、`START_MAINTENANCE`／`END_MAINTENANCE`、`UPDATE_INPUT_POS`、`TRAY_COMMAND`，以及 `OnSetThreadFocus` 送出的 keycode 0 焦點刷新探測）：`kClientFocusTimeoutMs`，漏掉一次下次事件自動補上。

失敗路徑：所有逾時／錯誤以 `DWORD` 例外丟出，由 `ClientImpl::_SendMessage` 既有的 `catch (DWORD)` 接住回 0，輸入法安靜降級（該次按鍵放行、下次自動重連），宿主程式不受影響。

### 2. `_Send()` 重連後改用新控制代碼

`PipeChannel::_Send()` 的 `catch` 區塊在 `_Reconnect()` 後仍以按值傳入的舊控制代碼重送，該次重送注定失敗；改為取 `_GetPipeHandle()` 重送。

### 3. 托盤刷新改於專用執行緒（#1912 的後續）

#1912 把 `Shell_NotifyIcon` 移到伺服器訊息執行緒，但訊息執行緒同時擁有候選視窗：管線工作執行緒在 `FocusIn` → `_UpdateUI()` 仍會對候選視窗做跨執行緒 `ShowWindow`／`SetWindowPos`，同步送訊息給訊息執行緒；而 `Shell_NotifyIcon` 內部以 `SMTO_BLOCK` 等工作列、期間不處理送入訊息。當工作列 UI 執行緒正在等管線回應時，環仍可能成立（只在焦點切換伴隨 UI 狀態改變時，窗口比原本窄）。

- `WeaselTrayIcon` 改由專用執行緒套用刷新：`RequestRefresh()` 存快照並喚醒，`RefreshThreadProc()` 合併待處理請求後呼叫 `Refresh()`，`DisableRefresh()`／解構子停止並 join。`Shell_NotifyIcon` 可自任一執行緒呼叫，回呼訊息仍送至 `hWnd` 所屬的訊息執行緒。
- 移除因此無用的 `WM_WEASEL_SERVICE_NOTIFY`、`ServerImpl::OnServiceNotifyMessage`、`Server::SetTrayRefreshCallback`。
- 移除 `_RefreshTrayIcon()` 對 `explorer.exe` 延遲 100 ms 另開執行緒的「Dangerous, don't touch」繞道：回呼已不阻塞，對任何客戶端同步呼叫皆安全。

若維護者希望保留 #1912 的訊息執行緒結構，第 3 個提交可單獨拆出另議。

## 逾時值

目前提交的值為 `kClientIoTimeoutMs = 500`、`kClientFocusTimeoutMs = 25`，是在 #1909 的環境（Windows 11 25H2、0.17.4）實測肉眼無感且輸入正常的值。
這兩個常數開放討論：若偏好保守，可改為焦點 100 ms／按鍵 1000～2000 ms，或改成可由 `weasel.yaml` 設定；我可依回饋調整。

## 測試

- Windows 11 25H2（build 26200）、x64 自建版，連續使用 2026-08-09 至 2026-08-22：多開視窗、快速點擊工作列切換，凍結消失；VS Code、Windows Terminal、檔案總管輸入正常；候選視窗、切換中英、部署通知行為不變。
- 與 #1912 同時套用（合入 `d73f629` 後重建）亦正常。
- 未測：ARM64、Win32 宿主（32 位元程式載入 32 位元 `weasel.dll`）——程式碼路徑相同，但未在實機驗證。（我沒有這種實機😭）

## 相關

- #1909（本 PR 對應的 issue，已隨 #1912 關閉）
- #1912（伺服器端修補，本 PR 為其互補）
- #1878（`_WritePipe` 在主執行緒阻塞，本 PR 的有界等待可涵蓋）
- #1867（範圍更大的重構，含等效的 `TryConnect()`／`TryTransact()`；本 PR 只取最小必要改動）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
