### PR TITLE
fix: 修復 LINE 密碼欄重複輸入與候選框問題

### DIFF
--- a/WeaselTSF/KeyEventSink.cpp
+++ b/WeaselTSF/KeyEventSink.cpp
@@ -1,14 +1,67 @@
 #include "stdafx.h"
+#include <UIAutomationClient.h>
 #include "WeaselIPC.h"
 #include "WeaselTSF.h"
 #include <KeyEvent.h>
 #include "CandidateList.h"
 
+#pragma comment(lib, "UIAutomationCore.lib")
+
 static weasel::KeyEvent prevKeyEvent;
 static BOOL prevfEaten = FALSE;
 static int keyCountToSimulate = 0;
 
+static bool IsLineProcess() {
+  WCHAR path[MAX_PATH]{};
+  if (!GetModuleFileNameW(nullptr, path, ARRAYSIZE(path)))
+    return false;
+  const WCHAR* name = wcsrchr(path, L'\\');
+  name = name ? name + 1 : path;
+  return _wcsicmp(name, L"LINE.exe") == 0;
+}
+
+static bool IsLinePasswordControlFocused() {
+  if (!IsLineProcess())
+    return false;
+
+  // OnTestKeyDown and OnKeyDown arrive back-to-back for the same physical key.
+  // Reuse the UIA result briefly to avoid making the same cross-provider query
+  // twice, while keeping focus changes responsive.
+  static thread_local ULONGLONG lastCheck = 0;
+  static thread_local bool lastResult = false;
+  const ULONGLONG now = GetTickCount64();
+  if (now - lastCheck < 50)
+    return lastResult;
+
+  lastCheck = now;
+  lastResult = false;
+
+  com_ptr<IUIAutomation> automation;
+  if (FAILED(CoCreateInstance(CLSID_CUIAutomation, nullptr,
+                              CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&automation))))
+    return false;
+
+  com_ptr<IUIAutomationElement> focused;
+  if (FAILED(automation->GetFocusedElement(&focused)) || !focused)
+    return false;
+
+  BOOL isPassword = FALSE;
+  if (SUCCEEDED(focused->get_CurrentIsPassword(&isPassword)))
+    lastResult = isPassword != FALSE;
+  return lastResult;
+}
+
 void WeaselTSF::_ProcessKeyEvent(WPARAM wParam, LPARAM lParam, BOOL* pfEaten) {
+  // LINE's Qt text store does not publish a password InputScope, but its
+  // focused UI Automation element correctly exposes IsPassword. Bypass Rime
+  // only for that control so raw password keys are not composed or committed.
+  if (IsLinePasswordControlFocused()) {
+    if (_IsComposing())
+      _AbortComposition();
+    *pfEaten = FALSE;
+    return;
+  }
+
   // when _IsKeyboardDisabled don't eat the key,
   // when keyboard closable and keyboard closed, don't eat the key
   if ((_isToOpenClose && !_IsKeyboardOpen()) || _IsKeyboardDisabled()) {


### PR DESCRIPTION
## 開發說明

此修補由 AI 協助完成，包括：

- 分析 Weasel TSF 組字流程
- 對照官方 master 的既有修正
- 撰寫 LINE 密碼欄的 UI Automation 相容處理
- 建置及檢查程式碼差異

實際問題重現、DLL 替換、LINE 密碼欄測試，以及最終效果確認均由本人完成。

由於目前只在個人環境驗證，且程式碼包含 `LINE.exe` 專用判斷，
因此將其定位為非官方 workaround，不建議直接視為通用修正。

## 問題原因

LINE 電腦版的密碼控制項沒有透過 TSF 提供密碼類型的
InputScope，導致小狼毫仍會建立組字狀態。

LINE 同時會自行接收原始按鍵，因此按下Enter確認組字時，會再次提交相同內容造成重複輸入；
密碼欄也會錯誤顯示候選框。

## 修正方式

當下列條件同時成立時，讓按鍵直接交由 LINE 處理，不送入 Rime：

- 目前程序為 `LINE.exe`
- 目前取得焦點的 UI Automation 元素回報 `IsPassword=true`

為避免 `OnTestKeyDown` 與 `OnKeyDown` 對同一次按鍵重複執行
UI Automation 查詢，加入 50 毫秒的執行緒區域快取。

## 實測結果

- LINE 密碼欄不再重複輸入
- 密碼欄不再顯示候選框
- 按 Enter 不會提交殘留組字
- LINE 帳號欄不受影響
- LINE 聊天輸入框仍可正常輸入中文

## 建置資訊

- 基於官方 master：`d73f629`
- 修補 commit：`e09ca36`
- Windows 11
- LINE Desktop x64