### PR TITLE
fix(WeaselIPC): bound client pipe I/O with timeouts to prevent host UI hangs

### DIFF
--- a/WeaselIPC/PipeChannel.cpp
+++ b/WeaselIPC/PipeChannel.cpp
@@ -40,8 +40,16 @@ bool PipeChannelBase::_Ensure() {
 
 HANDLE PipeChannelBase::_Connect(const wchar_t* name) {
   HANDLE pipe = INVALID_HANDLE_VALUE;
-  while (_Invalid(pipe = _TryConnect()))
-    ::WaitNamedPipe(name, 500);
+  const ULONGLONG deadline = ::GetTickCount64() + io_timeout;
+  while (_Invalid(pipe = _TryConnect())) {
+    if (io_timeout != INFINITE && ::GetTickCount64() >= deadline)
+      // WAIT_TIMEOUT 是 int 字面量，须按 DWORD 抛出才能被 catch(DWORD) 捕获
+      _ThrowCode(static_cast<DWORD>(WAIT_TIMEOUT));
+    // 管道实例全部忙时 WaitNamedPipe 会等待实例可用；而在算法服务重启等
+    // 场景下没有任何实例处于监听态，它会立即失败，稍作休眠避免忙转
+    if (!::WaitNamedPipe(name, 200))
+      ::Sleep(20);
+  }
   DWORD mode = PIPE_READMODE_MESSAGE;
   if (!SetNamedPipeHandleState(pipe, &mode, NULL, NULL)) {
     _ThrowLastError;
@@ -57,7 +65,7 @@ void PipeChannelBase::_Reconnect() {
 
 HANDLE PipeChannelBase::_TryConnect() {
   auto pipe = ::CreateFile(pname.c_str(), GENERIC_READ | GENERIC_WRITE, 0, NULL,
-                           OPEN_EXISTING, 0, NULL);
+                           OPEN_EXISTING, FILE_FLAG_OVERLAPPED, NULL);
   if (!_Invalid(pipe)) {
     // connected to the pipe
     return pipe;
@@ -68,12 +76,60 @@ HANDLE PipeChannelBase::_TryConnect() {
   return INVALID_HANDLE_VALUE;
 }
 
+HANDLE PipeChannelBase::_GetIoEvent() {
+  auto ctx = _GetContext();
+  if (ctx->io_event == NULL) {
+    ctx->io_event = ::CreateEventW(NULL, TRUE, FALSE, NULL);
+    if (ctx->io_event == NULL)
+      _ThrowLastError;
+  }
+  return ctx->io_event;
+}
+
+// 在重叠句柄上执行一次带超时的读写，返回传输字节数；
+// 失败时抛出 DWORD 错误码，超时以 WAIT_TIMEOUT 上报
+DWORD PipeChannelBase::_OverlappedIo(HANDLE pipe,
+                                     bool is_write,
+                                     LPVOID buffer,
+                                     DWORD len) {
+  HANDLE event = _GetIoEvent();
+  OVERLAPPED ov = {};
+  ov.hEvent = event;
+  ::ResetEvent(event);
+  BOOL pending = is_write ? ::WriteFile(pipe, buffer, len, NULL, &ov)
+                          : ::ReadFile(pipe, buffer, len, NULL, &ov);
+  if (!pending && ::GetLastError() != ERROR_IO_PENDING) {
+    // 同步完成（含 ERROR_MORE_DATA、ERROR_BROKEN_PIPE 等），直接上报错误码
+    throw ::GetLastError();
+  }
+  DWORD transferred = 0;
+  DWORD wait = ::WaitForSingleObject(event, io_timeout);
+  if (wait == WAIT_OBJECT_0) {
+    if (::GetOverlappedResult(pipe, &ov, &transferred, FALSE))
+      return transferred;
+    // 操作以错误状态完成，取消收尾后上报原错误码
+    DWORD err = ::GetLastError();
+    ::CancelIoEx(pipe, &ov);
+    ::GetOverlappedResult(pipe, &ov, &transferred, TRUE);
+    throw err;
+  }
+  if (wait == WAIT_FAILED)
+    _ThrowLastError;
+  // 超时：先取消未决操作，再以 WAIT_TIMEOUT 上报（转 DWORD 以匹配
+  // catch(DWORD)）
+  ::CancelIoEx(pipe, &ov);
+  ::GetOverlappedResult(pipe, &ov, &transferred, TRUE);
+  _ThrowCode(static_cast<DWORD>(WAIT_TIMEOUT));
+}
+
 size_t PipeChannelBase::_WritePipe(HANDLE pipe, size_t s, char* b) {
-  DWORD lwritten;
-  if (!::WriteFile(pipe, b, s, &lwritten, NULL) || lwritten <= 0) {
+  DWORD lwritten = _OverlappedIo(pipe, true, b, static_cast<DWORD>(s));
+  if (lwritten <= 0) {
     _ThrowLastError;
   }
-  ::FlushFileBuffers(pipe);
+  // 注：不调用 FlushFileBuffers。命名管道上它会等到对端读走数据才返回，
+  // 而请求/响应模式下对端本就必须先读完请求才会产生响应，
+  // 该调用只会把对端的迟滞变成调用方（宿主 UI 线程）的额外阻塞点
   return lwritten;
 }
 
@@ -86,28 +142,47 @@ void PipeChannelBase::_FinalizePipe(HANDLE& p) {
 }
 
 void PipeChannelBase::_Receive(HANDLE pipe, LPVOID msg, size_t rec_len) {
-  DWORD lread;
-  BOOL success = ::ReadFile(pipe, msg, rec_len, &lread, NULL);
-  if (!success) {
-    _ThrowIfNot(ERROR_MORE_DATA);
+  try {
+    _OverlappedIo(pipe, false, msg, static_cast<DWORD>(rec_len));
+  } catch (DWORD err) {
+    if (err != ERROR_MORE_DATA)
+      throw;
 
     auto ctx = _GetContext();
     memset(ctx->buffer.get(), 0, buff_size);
-    success = ::ReadFile(pipe, ctx->buffer.get(), buff_size, &lread, NULL);
-    if (!success) {
-      _ThrowLastError;
-    }
+    _OverlappedIo(pipe, false, ctx->buffer.get(),
+                  static_cast<DWORD>(buff_size));
   }
   _GetContext()->has_body = false;
 }
 
 HANDLE PipeChannelBase::_ConnectServerPipe(std::wstring& pn) {
   HANDLE pipe =
-      CreateNamedPipe(pn.c_str(), PIPE_ACCESS_DUPLEX,
+      CreateNamedPipe(pn.c_str(), PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED,
                       PIPE_TYPE_MESSAGE | PIPE_READMODE_MESSAGE | PIPE_WAIT,
                       PIPE_UNLIMITED_INSTANCES, buff_size, buff_size, 0, sa);
-  if (pipe == INVALID_HANDLE_VALUE || !::ConnectNamedPipe(pipe, NULL)) {
+  if (pipe == INVALID_HANDLE_VALUE) {
     _ThrowLastError;
+  }
+  OVERLAPPED ov = {};
+  ov.hEvent = _GetIoEvent();
+  if (!::ConnectNamedPipe(pipe, &ov)) {
+    DWORD err = ::GetLastError();
+    // 客户端在 CreateNamedPipe 与 ConnectNamedPipe 之间连入是合法竞态
+    if (err != ERROR_PIPE_CONNECTED) {
+      if (err != ERROR_IO_PENDING) {
+        ::CloseHandle(pipe);
+        throw err;
+      }
+      DWORD connected = 0;
+      if (!::GetOverlappedResult(pipe, &ov, &connected, TRUE)) {
+        err = ::GetLastError();
+        if (err != ERROR_PIPE_CONNECTED) {
+          ::CloseHandle(pipe);
+          throw err;
+        }
+      }
+    }
   }
   return pipe;
 }

--- a/WeaselIPC/WeaselClientImpl.cpp
+++ b/WeaselIPC/WeaselClientImpl.cpp
@@ -6,6 +6,9 @@ using namespace weasel;
 
 ClientImpl::ClientImpl()
     : session_id(0), channel(GetPipeName()), is_ime(false) {
+  // 管道请求在宿主 UI 线程上同步执行，设置有限超时，
+  // 避免算法服务无响应时拖死宿主窗口
+  channel.SetIoTimeout(WEASEL_PIPE_IO_TIMEOUT);
   _InitializeClientInfo();
 }
 

--- a/WeaselIPCServer/WeaselServerImpl.cpp
+++ b/WeaselIPCServer/WeaselServerImpl.cpp
@@ -428,6 +428,8 @@ void PipeServer::Listen(ServerHandler const& handler) {
           [&handler, pipe, this] { _ProcessPipeThread(pipe, handler); });
     } catch (DWORD ex) {
       _FinalizePipe(pipe);
+      // accept 持续失败时退避，避免监听线程全速空转
+      ::Sleep(20);
     }
     boost::this_thread::interruption_point();
   }

--- a/include/PipeChannel.h
+++ b/include/PipeChannel.h
@@ -16,13 +16,22 @@ class PipeChannelBase {
     std::unique_ptr<char[]> buffer;
     std::unique_ptr<Stream> write_stream;
     bool has_body;
+    // 供重叠 I/O 等待使用的手动复位事件，同一线程内串行复用
+    HANDLE io_event = NULL;
 
     ChannelContext(size_t bs)
         : buffer(std::make_unique<char[]>(bs)), has_body(false) {}
+
+    ~ChannelContext() {
+      if (io_event != NULL)
+        CloseHandle(io_event);
+    }
   };
 
   PipeChannelBase(std::wstring&& pn_cmd, size_t bs, SECURITY_ATTRIBUTES* s);
   ~PipeChannelBase();
+  // 设置单次管道 I/O 及连接等待的超时（毫秒），INFINITE 表示不限时
+  void SetIoTimeout(DWORD ms) { io_timeout = ms; }
 
  protected:
   /* To ensure connection before operation */
@@ -38,6 +47,10 @@ class PipeChannelBase {
   void _Receive(HANDLE pipe, LPVOID msg, size_t rec_len);
   /* Try to get a connection from client */
   HANDLE _ConnectServerPipe(std::wstring& pn);
+  /* Get the thread-local event for overlapped pipe I/O */
+  HANDLE _GetIoEvent();
+  /* Perform one overlapped read/write with timeout; throws DWORD on failure */
+  DWORD _OverlappedIo(HANDLE pipe, bool is_write, LPVOID buffer, DWORD len);
   inline bool _Invalid(HANDLE p) const { return p == INVALID_HANDLE_VALUE; }
 
   HANDLE* _GetPipeHandle() const {
@@ -61,6 +74,9 @@ class PipeChannelBase {
   const size_t buff_size;
   // Thread-local context for buffer and state
   mutable boost::thread_specific_ptr<ChannelContext> context;
+  // 单次管道 I/O / 连接等待超时；服务端保持 INFINITE，客户端设置有限值，
+  // 避免算法服务无响应时把宿主 UI 线程无限拖死
+  DWORD io_timeout = INFINITE;
 
  private:
   /* Security attributes */
@@ -169,6 +185,8 @@ class PipeChannel : public PipeChannelBase {
       _WritePipe(pipe, data_sz, pbuff);
     } catch (...) {
       _Reconnect();
+      // _Reconnect 可能已更换线程本地句柄，重新取用再重写
+      pipe = *_GetPipeHandle();
       _WritePipe(pipe, data_sz, pbuff);
     }
     ClearBufferStream();

--- a/include/WeaselIPC.h
+++ b/include/WeaselIPC.h
@@ -9,6 +9,12 @@
 #define WEASEL_IPC_WINDOW L"WeaselIPCWindow_1.0"
 #define WEASEL_IPC_PIPE_NAME L"WeaselNamedPipe"
 
+// 客户端命名管道 I/O 及连接等待的超时（毫秒）。
+// 管道请求在宿主程序的 UI 线程上同步执行，必须设置有限超时，
+// 在算法服务忙碌或重启期间把失败交还给既有的重连/守护逻辑，
+// 避免宿主窗口被无限拖死（#1696、#1909）
+constexpr DWORD WEASEL_PIPE_IO_TIMEOUT = 1000;
+
 #define WEASEL_IPC_METADATA_SIZE 1024
 #define WEASEL_IPC_BUFFER_SIZE (4 * 1024)
 #define WEASEL_IPC_BUFFER_LENGTH (WEASEL_IPC_BUFFER_SIZE / sizeof(WCHAR))


### PR DESCRIPTION
## 概要

fixed: #1696
fixed: #1909（客户端侧的另一半：#1912 已修复服务端托盘刷新阻塞 pipe worker 的问题，本 PR 补上客户端在宿主 UI 线程上无限等待的部分）

## 背景

WeaselTSF 载入到每个有文本输入的宿主进程内，按键处理、线程焦点切换（`OnSetThreadFocus`）、`_EnsureServerConnected` 等路径都会在**宿主程序的 UI 线程上**发起同步的管道请求/响应往返。当算法服务忙碌、正在重启或正在退出时，这些往返会被无限拖住，表现为整个系统的窗口冻结，只能用任务管理器结束 WeaselServer.exe 才能恢复（#1696、#1909）。

具体阻塞点都在 `WeaselIPC/PipeChannel.cpp`：

1. `_Connect()` 以 `while (_Invalid(pipe = _TryConnect())) ::WaitNamedPipe(name, 500)` 无限循环等待管道实例；而在服务重启窗口期内没有任何实例处于监听态，`WaitNamedPipe` 会立即返回 FALSE，循环还会全速空转。
2. `_WritePipe()` / `_Receive()` 使用阻塞式 `WriteFile` / `ReadFile`，没有超时。
3. `_WritePipe()` 中的 `FlushFileBuffers` 在命名管道上会一直等到对端把数据读走才返回；请求/响应模式下对端本就必须先读完请求才会产生响应，这一步只是把服务端的迟滞变成宿主 UI 线程的额外阻塞点。

## 改动

- 客户端管道句柄以 `FILE_FLAG_OVERLAPPED` 打开，读写统一走新增的 `_OverlappedIo()`：带可配置超时等待，超时先 `CancelIoEx` 收尾，再以 `WAIT_TIMEOUT` 上报；其余失败仍按既有 `DWORD` 错误码异常路径传播，由 `ClientImpl::_SendMessage` 与 WeaselTSF 既有的重连/守护逻辑接管，不在 UI 线程上同步重连。
- `ClientImpl` 设置 1 秒超时（`WEASEL_PIPE_IO_TIMEOUT`）；连接等待循环同样受该上限约束，`WaitNamedPipe` 立即失败时小睡 20ms 避免忙转。
- 移除 `FlushFileBuffers`。
- 服务端管道句柄同样改为重叠模式，但保持 `INFINITE` 等待，`_ProcessPipeThread` 等待请求、`Listen` 等待连接的语义与原先一致；`Listen()` 在 accept 持续失败时退避 20ms，避免监听线程全速空转；`CreateNamedPipe` 与 `ConnectNamedPipe` 之间客户端连入的合法竞态（`ERROR_PIPE_CONNECTED`）不再当作错误，避免白白丢弃已建立的连接。
- `_Send()` 在 `_Reconnect()` 之后重新取线程本地句柄，避免通过已关闭的旧句柄重写。

## 测试

- `./clang-format.sh -i`（clang-format 18）通过。
- 本地 msbuild（VS2022 / v143 / x64 Release）编译 `WeaselIPC`、`WeaselIPCServer` 通过，无新增警告。
